### PR TITLE
Feature/#3 api enhancement and testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,5 @@ out/
 application-local.yml
 
 firebase-service-account.json
+# Test utility controller
+src/main/java/com/example/chalpu/util/TestUtilController.java

--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,9 @@ dependencies {
 
 	// Firebase Admin SDK for FCM
     implementation 'com.google.firebase:firebase-admin:9.2.0'
+
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3:3.1.1'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/chalpu/common/exception/ErrorMessage.java
+++ b/src/main/java/com/example/chalpu/common/exception/ErrorMessage.java
@@ -74,6 +74,8 @@ public enum ErrorMessage {
     FOOD_UPDATE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "음식 정보 수정에 실패했습니다."),
     
     // 사진 관련 에러
+    PRESIGNED_URL_GENERATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "사진 업로드를 위한 URL 생성에 실패했습니다."),
+    PHOTO_REGISTRATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "사진 정보 등록에 실패했습니다."),
     PHOTO_NOT_FOUND(NOT_FOUND, "사진을 찾을 수 없습니다."),
     PHOTO_ACCESS_DENIED(FORBIDDEN, "사진 접근 권한이 없습니다."),
     PHOTO_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "사진 업로드에 실패했습니다."),

--- a/src/main/java/com/example/chalpu/guide/controller/GuideController.java
+++ b/src/main/java/com/example/chalpu/guide/controller/GuideController.java
@@ -1,0 +1,66 @@
+package com.example.chalpu.guide.controller;
+
+import com.example.chalpu.common.response.ApiResponse;
+import com.example.chalpu.guide.dto.GuidePresignedUrlResponse;
+import com.example.chalpu.guide.dto.GuideRegisterRequest;
+import com.example.chalpu.guide.dto.GuideResponse;
+import com.example.chalpu.guide.dto.GuideUploadRequest;
+import com.example.chalpu.guide.service.GuideService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+import com.example.chalpu.common.response.PageResponse;
+
+@RestController
+@RequestMapping("/api/guides")
+@RequiredArgsConstructor
+@Tag(name = "가이드 API (Admin)", description = "가이드(XML) 파일 관련 API. 어드민 권한이 필요합니다.")
+@PreAuthorize("hasRole('ADMIN')")
+public class GuideController {
+
+    private final GuideService guideService;
+
+    @Operation(summary = "가이드 전체 목록 조회 (Admin)", description = "모든 가이드 목록을 페이지네이션하여 조회합니다.")
+    @GetMapping
+    public ApiResponse<PageResponse<GuideResponse>> getAllGuides(@PageableDefault(size = 10) Pageable pageable) {
+        return ApiResponse.success(guideService.getAllGuides(pageable));
+    }
+
+    @Operation(summary = "가이드 상세 조회 (Admin)", description = "특정 가이드의 상세 정보를 조회합니다.")
+    @GetMapping("/{guideId}")
+    public ApiResponse<GuideResponse> getGuide(@PathVariable Long guideId) {
+        return ApiResponse.success(guideService.getGuide(guideId));
+    }
+
+    @Operation(summary = "가이드 업로드용 Presigned URL 생성 (Admin)", description = """
+            가이드 XML 파일을 S3에 직접 업로드하기 위한 Presigned URL을 생성합니다.
+            
+            **클라이언트 처리 순서:**
+            1. 이 API를 호출하여 `presignedUrl`과 `s3Key`를 받습니다.
+            2. 받은 `presignedUrl`을 목적지로, 업로드할 XML 파일의 원본 데이터를 body에 담아 **HTTP PUT** 요청을 보냅니다.
+               - **주의:** `Content-Type` 헤더에 반드시 `application/xml`을 포함해야 합니다.
+            3. S3 업로드가 성공하면, `/api/guides/register` API를 호출하여 업로드 완료 사실을 서버에 알립니다.
+            """)
+    @PostMapping("/presigned-url")
+    public ApiResponse<GuidePresignedUrlResponse> generatePresignedUrl(@RequestBody GuideUploadRequest request) {
+        return ApiResponse.success(guideService.generatePresignedUrl(request));
+    }
+
+    @Operation(summary = "가이드 정보 등록 (Admin)", description = "S3에 가이드 파일 업로드 완료 후, 파일 메타데이터를 서버에 등록합니다.")
+    @PostMapping("/register")
+    public ApiResponse<GuideResponse> registerGuide(@RequestBody GuideRegisterRequest request) {
+        return ApiResponse.success(guideService.registerGuide(request));
+    }
+
+    @Operation(summary = "가이드 삭제 (Admin)", description = "특정 가이드 정보를 DB에서 삭제하고, S3에 있는 실제 파일도 함께 삭제합니다.")
+    @DeleteMapping("/{guideId}")
+    public ApiResponse<Void> deleteGuide(@PathVariable Long guideId) {
+        guideService.deleteGuide(guideId);
+        return ApiResponse.success();
+    }
+} 

--- a/src/main/java/com/example/chalpu/guide/domain/Guide.java
+++ b/src/main/java/com/example/chalpu/guide/domain/Guide.java
@@ -1,0 +1,32 @@
+package com.example.chalpu.guide.domain;
+
+import com.example.chalpu.common.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "guides")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Guide extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "guide_id")
+    private Long id;
+
+    @Column(length = 500, nullable = false, unique = true)
+    private String s3Key;
+
+    @Column(length = 255, nullable = false)
+    private String fileName;
+
+    @Builder
+    private Guide(String s3Key, String fileName) {
+        this.s3Key = s3Key;
+        this.fileName = fileName;
+    }
+} 

--- a/src/main/java/com/example/chalpu/guide/dto/GuidePresignedUrlResponse.java
+++ b/src/main/java/com/example/chalpu/guide/dto/GuidePresignedUrlResponse.java
@@ -1,0 +1,16 @@
+package com.example.chalpu.guide.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class GuidePresignedUrlResponse {
+
+    @Schema(description = "파일 업로드에 사용할 S3 Presigned URL")
+    private String presignedUrl;
+
+    @Schema(description = "S3에 저장될 파일의 고유 키 (경로 포함). 업로드 완료 후 서버에 알려줘야 합니다.")
+    private String s3Key;
+} 

--- a/src/main/java/com/example/chalpu/guide/dto/GuideRegisterRequest.java
+++ b/src/main/java/com/example/chalpu/guide/dto/GuideRegisterRequest.java
@@ -1,0 +1,15 @@
+package com.example.chalpu.guide.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class GuideRegisterRequest {
+    @Schema(description = "S3에 업로드된 파일의 고유 키 (Presigned URL 생성 시 받은 값)", example = "guides/c1f8f3a3-3b1b-4b8b-8b5b-4b8b8b5b4b8b.xml")
+    private String s3Key;
+
+    @Schema(description = "업로드한 파일의 원본 이름", example = "guide_v1.xml")
+    private String fileName;
+} 

--- a/src/main/java/com/example/chalpu/guide/dto/GuideResponse.java
+++ b/src/main/java/com/example/chalpu/guide/dto/GuideResponse.java
@@ -1,0 +1,34 @@
+package com.example.chalpu.guide.dto;
+
+import com.example.chalpu.guide.domain.Guide;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class GuideResponse {
+
+    @Schema(description = "가이드 ID")
+    private Long id;
+
+    @Schema(description = "S3 키")
+    private String s3Key;
+
+    @Schema(description = "원본 파일명")
+    private String fileName;
+
+    @Schema(description = "생성일")
+    private LocalDateTime createdAt;
+
+    public static GuideResponse from(Guide guide) {
+        return GuideResponse.builder()
+                .id(guide.getId())
+                .s3Key(guide.getS3Key())
+                .fileName(guide.getFileName())
+                .createdAt(guide.getCreatedAt())
+                .build();
+    }
+} 

--- a/src/main/java/com/example/chalpu/guide/dto/GuideUploadRequest.java
+++ b/src/main/java/com/example/chalpu/guide/dto/GuideUploadRequest.java
@@ -1,0 +1,16 @@
+package com.example.chalpu.guide.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class GuideUploadRequest {
+
+    @Schema(description = "업로드할 가이드 파일의 원본 이름 (확장자 포함)", example = "guide_v1.xml")
+    private String fileName;
+
+    @Schema(description = "파일의 Content Type. XML 파일이므로 'application/xml'로 고정됩니다.", example = "application/xml", requiredMode = Schema.RequiredMode.NOT_REQUIRED, hidden = true)
+    private final String contentType = "application/xml";
+} 

--- a/src/main/java/com/example/chalpu/guide/repository/GuideRepository.java
+++ b/src/main/java/com/example/chalpu/guide/repository/GuideRepository.java
@@ -1,0 +1,7 @@
+package com.example.chalpu.guide.repository;
+
+import com.example.chalpu.guide.domain.Guide;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface GuideRepository extends JpaRepository<Guide, Long> {
+} 

--- a/src/main/java/com/example/chalpu/guide/service/GuideService.java
+++ b/src/main/java/com/example/chalpu/guide/service/GuideService.java
@@ -1,0 +1,133 @@
+package com.example.chalpu.guide.service;
+
+import com.example.chalpu.common.response.PageResponse;
+import com.example.chalpu.guide.domain.Guide;
+import com.example.chalpu.guide.dto.GuidePresignedUrlResponse;
+import com.example.chalpu.guide.dto.GuideRegisterRequest;
+import com.example.chalpu.guide.dto.GuideResponse;
+import com.example.chalpu.guide.dto.GuideUploadRequest;
+import com.example.chalpu.guide.repository.GuideRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
+
+import java.net.URL;
+import java.time.Duration;
+import java.util.UUID;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class GuideService {
+
+    private final GuideRepository guideRepository;
+    private final S3Presigner s3Presigner;
+    private final S3Client s3Client;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    private static final String GUIDE_S3_KEY_PREFIX = "guides/";
+
+    public GuideResponse getGuide(Long guideId) {
+        log.info("[GuideService] 가이드 상세 조회 시작. guideId: {}", guideId);
+        Guide guide = guideRepository.findById(guideId)
+                .orElseThrow(() -> new RuntimeException("해당 가이드를 찾을 수 없습니다.")); // TODO: GuideException으로 교체
+        log.info("[GuideService] 가이드 상세 조회 완료. guideId: {}", guideId);
+        return GuideResponse.from(guide);
+    }
+
+    public PageResponse<GuideResponse> getAllGuides(Pageable pageable) {
+        log.info("[GuideService] 가이드 전체 조회 시작. page: {}, size: {}", pageable.getPageNumber(), pageable.getPageSize());
+        Page<Guide> guides = guideRepository.findAll(pageable);
+        Page<GuideResponse> guideResponses = guides.map(GuideResponse::from);
+        log.info("[GuideService] 가이드 전체 조회 완료. totalElements: {}", guides.getTotalElements());
+        return PageResponse.from(guideResponses);
+    }
+
+    public GuidePresignedUrlResponse generatePresignedUrl(GuideUploadRequest request) {
+        log.info("[GuideService] Presigned URL 생성 시작. fileName: {}", request.getFileName());
+        String s3Key = createS3Key();
+
+        try {
+            URL url = createPresignedUrl(s3Key);
+            log.info("[GuideService] Presigned URL 생성 완료. s3Key: {}", s3Key);
+            return new GuidePresignedUrlResponse(url.toString(), s3Key);
+        } catch (Exception e) {
+            log.error("[GuideService] Presigned URL 생성 실패.", e);
+            // TODO: GuideException 추가 및 전용 에러 메시지 사용
+            throw new RuntimeException("Presigned URL 생성에 실패했습니다.", e);
+        }
+    }
+
+    @Transactional
+    public GuideResponse registerGuide(GuideRegisterRequest request) {
+        log.info("[GuideService] 가이드 등록 시작. s3Key: {}", request.getS3Key());
+        // TODO: S3에 파일이 실제로 존재하는지 확인하는 로직 추가
+
+        Guide guide = Guide.builder()
+                .s3Key(request.getS3Key())
+                .fileName(request.getFileName())
+                .build();
+
+        Guide savedGuide = guideRepository.save(guide);
+        log.info("[GuideService] 가이드 등록 완료. guideId: {}", savedGuide.getId());
+        return GuideResponse.from(savedGuide);
+    }
+
+    @Transactional
+    public void deleteGuide(Long guideId) {
+        log.info("[GuideService] 가이드 삭제 시작. guideId: {}", guideId);
+        
+        Guide guide = guideRepository.findById(guideId)
+                .orElseThrow(() -> new RuntimeException("해당 가이드를 찾을 수 없습니다.")); // TODO: GuideException으로 교체
+
+        deleteS3Object(guide.getS3Key());
+        
+        guideRepository.delete(guide);
+        log.info("[GuideService] 가이드 삭제 완료. guideId: {}", guideId);
+    }
+    
+    private void deleteS3Object(String s3Key) {
+        try {
+            DeleteObjectRequest deleteObjectRequest = DeleteObjectRequest.builder()
+                    .bucket(bucket)
+                    .key(s3Key)
+                    .build();
+            s3Client.deleteObject(deleteObjectRequest);
+            log.info("[GuideService] S3 파일 삭제 완료. s3Key: {}", s3Key);
+        } catch (Exception e) {
+            log.error("[GuideService] S3 파일 삭제 실패. s3Key: {}", s3Key, e);
+            throw new RuntimeException("S3 파일 삭제에 실패했습니다."); // TODO: 전용 예외 처리
+        }
+    }
+
+    private String createS3Key() {
+        return GUIDE_S3_KEY_PREFIX + UUID.randomUUID() + ".xml";
+    }
+
+    private URL createPresignedUrl(final String s3Key) {
+        PutObjectRequest objectRequest = PutObjectRequest.builder()
+                .bucket(bucket)
+                .key(s3Key)
+                .contentType("application/xml")
+                .build();
+
+        PutObjectPresignRequest presignRequest = PutObjectPresignRequest.builder()
+                .signatureDuration(Duration.ofMinutes(10))
+                .putObjectRequest(objectRequest)
+                .build();
+
+        return s3Presigner.presignPutObject(presignRequest).url();
+    }
+} 

--- a/src/main/java/com/example/chalpu/oauth/config/SecurityConfig.java
+++ b/src/main/java/com/example/chalpu/oauth/config/SecurityConfig.java
@@ -37,7 +37,7 @@ public class SecurityConfig {
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
                         // 공개 경로
-                        .requestMatchers("/", "/login", "/login.html", "/error", "/favicon.ico").permitAll()
+                        .requestMatchers("/", "/login", "/login.html", "/error", "/favicon.ico","/util/token").permitAll()
                         .requestMatchers("/index.html","/test.html","/landing/**").permitAll()
                         .requestMatchers("/api/auth/refresh", "/api/auth/logout", "/api/auth/me").permitAll()
                         .requestMatchers("/api/test/**").permitAll() // 테스트용 엔드포인트 전체 허용

--- a/src/main/java/com/example/chalpu/oauth/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/example/chalpu/oauth/security/jwt/JwtTokenProvider.java
@@ -71,6 +71,23 @@ public class JwtTokenProvider {
                 .compact();
     }
 
+    /**
+     * 테스트용 Access Token 생성 (10년)
+     */
+    public String generateTestAccessToken(Long userId, String email) {
+        Instant now = Instant.now();
+        Instant expiration = now.plus(3650, ChronoUnit.DAYS); // 10 years
+
+        return Jwts.builder()
+                .setSubject(userId.toString())
+                .claim("email", email)
+                .claim("type", "access")
+                .setIssuedAt(Date.from(now))
+                .setExpiration(Date.from(expiration))
+                .signWith(secretKey)
+                .compact();
+    }
+
     // 토큰에서 사용자 ID 추출
     public Long getUserIdFromToken(String token) {
         return Long.parseLong(getClaimsFromToken(token).getSubject());

--- a/src/main/java/com/example/chalpu/photo/controller/PhotoController.java
+++ b/src/main/java/com/example/chalpu/photo/controller/PhotoController.java
@@ -3,7 +3,10 @@ package com.example.chalpu.photo.controller;
 import com.example.chalpu.common.response.ApiResponse;
 import com.example.chalpu.common.response.PageResponse;
 import com.example.chalpu.oauth.security.jwt.UserDetailsImpl;
+import com.example.chalpu.photo.dto.PhotoPresignedUrlResponse;
+import com.example.chalpu.photo.dto.PhotoRegisterRequest;
 import com.example.chalpu.photo.dto.PhotoResponse;
+import com.example.chalpu.photo.dto.PhotoUploadRequest;
 import com.example.chalpu.photo.service.PhotoService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
@@ -13,71 +16,66 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 @RestController
-@RequestMapping("/api/foods/{foodId}/photos")
+@RequestMapping("/api/photos")
 @RequiredArgsConstructor
-@Tag(name = "Photo", description = "사진 관련 API")
+@Tag(name = "사진 API", description = "사진 관련 API")
 public class PhotoController {
 
     private final PhotoService photoService;
 
-    @PostMapping
-    @Operation(
-        summary = "음식 사진 업로드",
-        description = "특정 음식에 사진을 업로드합니다.",
-        security = { @SecurityRequirement(name = "bearerAuth") }
-    )
-    public ResponseEntity<ApiResponse<PhotoResponse>> uploadPhoto(
-            @PathVariable Long foodId,
-            @RequestParam("file") MultipartFile file,
-            @AuthenticationPrincipal UserDetailsImpl currentUser) {
-        PhotoResponse photo = photoService.uploadPhoto(foodId, file, currentUser.getId());
-        return ResponseEntity.ok(ApiResponse.success("사진 업로드가 완료되었습니다.", photo));
+    @Operation(summary = "Presigned URL 생성", description = """
+            클라이언트가 AWS S3에 파일을 직접 업로드하기 위해 사용하는 Presigned URL을 생성합니다.
+            
+            **클라이언트 처리 순서:**
+            1. 이 API를 호출하여 `presignedUrl`과 `s3Key`를 받습니다.
+            2. 받은 `presignedUrl`을 목적지로, 업로드할 파일의 원본 데이터를 body에 담아 **HTTP PUT** 요청을 보냅니다.
+               - **주의:** `Content-Type` 헤더에 반드시 실제 파일의 MIME 타입(예: `image/jpeg`)을 포함해야 합니다.
+            3. S3 업로드가 성공(HTTP 200 OK)하면, `/api/photos/register` API를 호출하여 업로드 완료 사실을 서버에 알립니다.
+               - 이때 응답으로 받았던 `s3Key`와 파일의 원본 이름 등 필요한 메타데이터를 함께 전송합니다.
+            """)
+    @PostMapping("/presigned-url")
+    public ApiResponse<PhotoPresignedUrlResponse> generatePresignedUrl(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @RequestBody PhotoUploadRequest request) {
+        String username = userDetails.getUsername();
+        return ApiResponse.success(photoService.generatePresignedUrl(username, request));
     }
 
-    @GetMapping
-    @Operation(
-        summary = "음식 사진 목록",
-        description = """
-                특정 음식의 모든 사진 목록을 조회합니다.
-                
-                **페이지네이션 파라미터:**
-                - `page`: 페이지 번호 (0부터 시작, 기본값: 0)
-                - `size`: 페이지 크기 (기본값: 20)
-                - `sort`: 정렬 조건 (선택사항)
-                
-                **요청 예시:**
-                ```
-                GET /api/foods/{foodId}/photos?page=0&size=10&sort=uploadDate,desc&sort=fileName,asc
-                ```
-                위처럼 정렬 조건을 리스트로 줘도 되고 아래처럼 String으로 줘도 됩니다.
-                ```
-                GET /api/foods/{foodId}/photos?page=0&size=10&sort=uploadDate,desc
-                ```
-                """,
-        security = { @SecurityRequirement(name = "bearerAuth") }
-    )
-    public ResponseEntity<ApiResponse<PageResponse<PhotoResponse>>> getPhotos(
-            @PathVariable Long foodId,
-            @PageableDefault(size = 20) Pageable pageable) {
-        PageResponse<PhotoResponse> photos = photoService.getPhotos(foodId, pageable);
-        return ResponseEntity.ok(ApiResponse.success("사진 목록 조회가 완료되었습니다.", photos));
+    @Operation(summary = "사진 정보 등록", description = "S3에 업로드 완료 후, 파일 메타데이터를 서버에 등록합니다.")
+    @PostMapping("/register")
+    public ApiResponse<PhotoResponse> registerPhoto(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @RequestBody PhotoRegisterRequest request) {
+        String username = userDetails.getUsername();
+        return ApiResponse.success(photoService.registerPhoto(username, request));
+    }
+    
+    @Operation(summary = "가게별 사진 목록 조회", description = "특정 가게에 속한 사진 목록을 페이지네이션하여 조회합니다.")
+    @GetMapping("/store/{storeId}")
+    public ApiResponse<PageResponse<PhotoResponse>> getPhotosByStore(
+            @PathVariable Long storeId,
+            @PageableDefault(size = 10) Pageable pageable) {
+        return ApiResponse.success(photoService.getPhotosByStore(storeId, pageable));
     }
 
-    @PatchMapping("/{photoId}/feature")
-    @Operation(
-        summary = "대표 사진 지정",
-        description = "특정 사진을 대표 사진으로 지정합니다.",
-        security = { @SecurityRequirement(name = "bearerAuth") }
-    )
-    public ResponseEntity<ApiResponse<PhotoResponse>> setFeaturedPhoto(
-            @PathVariable Long foodId,
-            @PathVariable Long photoId,
-            @AuthenticationPrincipal UserDetailsImpl currentUser) {
-        PhotoResponse photo = photoService.setFeaturedPhoto(foodId, photoId, currentUser.getId());
-        return ResponseEntity.ok(ApiResponse.success("대표 사진 지정이 완료되었습니다.", photo));
+    @Operation(summary = "사진 상세 조회", description = "특정 사진의 상세 정보를 조회합니다.")
+    @GetMapping("/{photoId}")
+    public ApiResponse<PhotoResponse> getPhoto(@PathVariable Long photoId) {
+        return ApiResponse.success(photoService.getPhoto(photoId));
+    }
+
+    @Operation(summary = "사진 삭제", description = "특정 사진을 삭제합니다.")
+    @DeleteMapping("/{photoId}")
+    public ApiResponse<Void> deletePhoto(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @PathVariable Long photoId) {
+        String username = userDetails.getUsername();
+        photoService.deletePhoto(username, photoId);
+        return ApiResponse.success();
     }
 } 

--- a/src/main/java/com/example/chalpu/photo/domain/Photo.java
+++ b/src/main/java/com/example/chalpu/photo/domain/Photo.java
@@ -33,8 +33,8 @@ public class Photo extends BaseTimeEntity {
     @JoinColumn(name = "food_id")
     private FoodItem foodItem;
 
-    @Column(length = 500, nullable = false)
-    private String filePath;
+    @Column(length = 500, nullable = false, unique = true)
+    private String s3Key;
 
     @Column(length = 255, nullable = false)
     private String fileName;
@@ -43,9 +43,6 @@ public class Photo extends BaseTimeEntity {
     private Integer fileSize;
     private Integer imageWidth;
     private Integer imageHeight;
-
-    @Column(nullable = false, updatable = false)
-    private Timestamp uploadDate;
 
     @Builder.Default
     private Boolean isFeatured = false;

--- a/src/main/java/com/example/chalpu/photo/dto/PhotoPresignedUrlResponse.java
+++ b/src/main/java/com/example/chalpu/photo/dto/PhotoPresignedUrlResponse.java
@@ -1,0 +1,21 @@
+package com.example.chalpu.photo.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "Presigned URL 발급 응답")
+public class PhotoPresignedUrlResponse {
+
+    @Schema(description = "S3에 업로드할 때 사용할, 유효기간이 설정된 URL")
+    private String presignedUrl;
+
+    @Schema(description = "업로드 후 S3에 저장될 파일의 고유 키. 업로드 완료 API 호출 시 필요.", example = "photos/stores/1/a1b2c3d4-e5f6-7890-1234-567890abcdef.jpg")
+    private String s3Key;
+} 

--- a/src/main/java/com/example/chalpu/photo/dto/PhotoRegisterRequest.java
+++ b/src/main/java/com/example/chalpu/photo/dto/PhotoRegisterRequest.java
@@ -1,0 +1,37 @@
+package com.example.chalpu.photo.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "S3 업로드 완료 후 사진 정보 등록 요청")
+public class PhotoRegisterRequest {
+
+    @Schema(description = "Presigned URL 발급 시 받았던 S3 파일 키", example = "photos/stores/1/a1b2c3d4-e5f6-7890-1234-567890abcdef.jpg")
+    private String s3Key;
+
+    @Schema(description = "업로드한 파일의 원본 이름", example = "kimchi-stew.jpg")
+    private String fileName;
+    
+    @Schema(description = "사진이 속한 가게의 ID", example = "1")
+    private Long storeId;
+
+    @Schema(description = "사진이 속한 음식 아이템의 ID (선택)", example = "10")
+    private Long foodItemId;
+    
+    // 필요에 따라 파일 사이즈, 가로/세로 길이 등 추가 메타데이터 포함 가능
+    @Schema(description = "파일 크기 (bytes)", example = "3145728")
+    private Integer fileSize;
+    
+    @Schema(description = "이미지 가로 길이 (px)", example = "1920")
+    private Integer imageWidth;
+
+    @Schema(description = "이미지 세로 길이 (px)", example = "1080")
+    private Integer imageHeight;
+} 

--- a/src/main/java/com/example/chalpu/photo/dto/PhotoResponse.java
+++ b/src/main/java/com/example/chalpu/photo/dto/PhotoResponse.java
@@ -7,7 +7,6 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import java.sql.Timestamp;
 import java.time.LocalDateTime;
 
 @Data
@@ -20,65 +19,52 @@ public class PhotoResponse {
     @Schema(description = "사진 ID", example = "1")
     private Long id;
     
-    @Schema(description = "업로드한 사용자 ID", example = "1")
-    private Long userId;
-    
     @Schema(description = "매장 ID", example = "1")
     private Long storeId;
     
     @Schema(description = "음식 ID", example = "1")
     private Long foodId;
     
-    @Schema(description = "파일 경로", example = "/uploads/photos/20240115/image.jpg")
-    private String filePath;
+    @Schema(description = "CloudFront를 통해 접근 가능한 이미지 전체 URL", example = "https://cdn.chalpu.com/photos/stores/1/image.jpg")
+    private String imageUrl;
     
-    @Schema(description = "파일명", example = "image.jpg")
+    @Schema(description = "원본 파일명", example = "image.jpg")
     private String fileName;
     
-    @Schema(description = "필터", example = "VINTAGE")
-    private String filter;
-    
-    @Schema(description = "파일 크기", example = "1024")
+    @Schema(description = "파일 크기 (bytes)", example = "1024")
     private Integer fileSize;
     
-    @Schema(description = "이미지 너비", example = "1920")
+    @Schema(description = "이미지 너비 (px)", example = "1920")
     private Integer imageWidth;
     
-    @Schema(description = "이미지 높이", example = "1080")
+    @Schema(description = "이미지 높이 (px)", example = "1080")
     private Integer imageHeight;
-    
-    @Schema(description = "업로드 시간", example = "2024-01-15T09:30:00")
-    private Timestamp uploadDate;
     
     @Schema(description = "대표 사진 여부", example = "false")
     private Boolean isFeatured;
     
-    @Schema(description = "활성화 여부", example = "true")
-    private Boolean isActive;
-    
     @Schema(description = "생성 시간", example = "2024-01-15T09:30:00")
     private LocalDateTime createdAt;
     
-    @Schema(description = "수정 시간", example = "2024-01-15T10:30:00")
-    private LocalDateTime updatedAt;
-    
-    public static PhotoResponse from(Photo photo) {
+    public static PhotoResponse from(Photo photo, String cloudfrontDomain) {
         return PhotoResponse.builder()
                 .id(photo.getId())
-                .userId(photo.getUser() != null ? photo.getUser().getId() : null)
                 .storeId(photo.getStore() != null ? photo.getStore().getId() : null)
                 .foodId(photo.getFoodItem() != null ? photo.getFoodItem().getId() : null)
-                .filePath(photo.getFilePath())
+                .imageUrl(buildFullUrl(cloudfrontDomain, photo.getS3Key()))
                 .fileName(photo.getFileName())
-                .filter(photo.getFilter())
                 .fileSize(photo.getFileSize())
                 .imageWidth(photo.getImageWidth())
                 .imageHeight(photo.getImageHeight())
-                .uploadDate(photo.getUploadDate())
                 .isFeatured(photo.getIsFeatured())
-                .isActive(photo.getIsActive())
                 .createdAt(photo.getCreatedAt())
-                .updatedAt(photo.getUpdatedAt())
                 .build();
+    }
+    
+    private static String buildFullUrl(String cloudfrontDomain, String s3Key) {
+        if (cloudfrontDomain == null || s3Key == null) {
+            return null;
+        }
+        return cloudfrontDomain.endsWith("/") ? cloudfrontDomain + s3Key : cloudfrontDomain + "/" + s3Key;
     }
 } 

--- a/src/main/java/com/example/chalpu/photo/dto/PhotoUploadRequest.java
+++ b/src/main/java/com/example/chalpu/photo/dto/PhotoUploadRequest.java
@@ -10,12 +10,9 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-@Schema(description = "사진 업로드 요청")
+@Schema(description = "사진 업로드를 위한 Presigned URL 요청")
 public class PhotoUploadRequest {
-    
-    @Schema(description = "필터", example = "VINTAGE")
-    private String filter;
-    
-    @Schema(description = "설명", example = "맛있는 김치찌개 사진")
-    private String description;
-} 
+
+    @Schema(description = "업로드할 파일의 원본 이름", example = "kimchi-stew.jpg")
+    private String fileName;
+}

--- a/src/main/java/com/example/chalpu/photo/repository/PhotoRepository.java
+++ b/src/main/java/com/example/chalpu/photo/repository/PhotoRepository.java
@@ -14,4 +14,6 @@ public interface PhotoRepository extends JpaRepository<Photo, Long> {
     List<Photo> findByFoodItemId(Long foodId);
     
     Page<Photo> findByFoodItemId(Long foodId, Pageable pageable);
+
+    Page<Photo> findByStoreId(Long storeId, Pageable pageable);
 } 

--- a/src/main/java/com/example/chalpu/photo/service/PhotoService.java
+++ b/src/main/java/com/example/chalpu/photo/service/PhotoService.java
@@ -4,17 +4,31 @@ import com.example.chalpu.common.exception.ErrorMessage;
 import com.example.chalpu.common.exception.PhotoException;
 import com.example.chalpu.common.response.PageResponse;
 import com.example.chalpu.photo.domain.Photo;
+import com.example.chalpu.photo.dto.PhotoPresignedUrlResponse;
+import com.example.chalpu.photo.dto.PhotoRegisterRequest;
 import com.example.chalpu.photo.dto.PhotoResponse;
+import com.example.chalpu.photo.dto.PhotoUploadRequest;
 import com.example.chalpu.photo.repository.PhotoRepository;
+import com.example.chalpu.store.domain.Store;
+import com.example.chalpu.store.repository.StoreRepository;
+import com.example.chalpu.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
 
-import java.util.List;
+import java.net.URL;
+import java.time.Duration;
+import java.util.Objects;
+import java.util.UUID;
 
 @Slf4j
 @Service
@@ -23,116 +37,139 @@ import java.util.List;
 public class PhotoService {
 
     private final PhotoRepository photoRepository;
+    private final StoreRepository storeRepository;
+    private final S3Presigner s3Presigner;
+    private final S3Client s3Client;
 
-    /**
-     * 사진 업로드
-     */
-    @Transactional
-    public PhotoResponse uploadPhoto(Long foodId, MultipartFile file, Long userId) {
-        log.info("uploadPhoto 시작 - foodId: {}, fileName: {}, userId: {}", 
-                foodId, file.getOriginalFilename(), userId);
-        
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    @Value("${cloud.aws.cloudfront.domain}")
+    private String cloudfrontDomain;
+
+    public PhotoPresignedUrlResponse generatePresignedUrl(final String username, final PhotoUploadRequest request) {
+        log.info("[PhotoService] generatePresignedUrl for user: {}, fileName: {}", username, request.getFileName());
+        // ToDo: 사용자 권한 검증 로직 추가 (e.g., storeId를 받아서 해당 가게의 관리자인지 확인)
         try {
-            // TODO: 파일 업로드 로직 구현
-            Photo photo = createPhotoEntity(file, foodId);
-            Photo savedPhoto = photoRepository.save(photo);
-            
-            log.info("uploadPhoto 성공 - photoId: {}, fileName: {}", 
-                    savedPhoto.getId(), savedPhoto.getFileName());
-            
-            return PhotoResponse.from(savedPhoto);
+            String s3Key = createS3Key(request.getFileName());
+            URL presignedUrl = createPresignedUrl(s3Key);
+
+            return PhotoPresignedUrlResponse.builder()
+                    .presignedUrl(presignedUrl.toString())
+                    .s3Key(s3Key)
+                    .build();
         } catch (Exception e) {
-            log.error("uploadPhoto 실패 - foodId: {}, fileName: {}, error: {}", 
-                    foodId, file.getOriginalFilename(), e.getMessage(), e);
-            throw new PhotoException(ErrorMessage.PHOTO_UPLOAD_FAILED);
+            log.error("[PhotoService] Failed to generate presigned URL for user: {}. Error: {}", username, e.getMessage());
+            throw new PhotoException(ErrorMessage.PRESIGNED_URL_GENERATION_FAILED);
         }
     }
 
-    /**
-     * 음식별 사진 목록 조회
-     */
-    public PageResponse<PhotoResponse> getPhotos(Long foodId, Pageable pageable) {
-        log.info("getPhotos 시작 - foodId: {}, page: {}, size: {}", 
-                foodId, pageable.getPageNumber(), pageable.getPageSize());
-        
+    @Transactional
+    public PhotoResponse registerPhoto(final String username, final PhotoRegisterRequest request) {
+        log.info("[PhotoService] registerPhoto for user: {}, s3Key: {}", username, request.getS3Key());
         try {
-            Page<Photo> photoPage = photoRepository.findByFoodItemId(foodId, pageable);
-            Page<PhotoResponse> photoResponsePage = photoPage.map(PhotoResponse::from);
-            
-            log.info("getPhotos 성공 - foodId: {}, totalElements: {}", 
-                    foodId, photoPage.getTotalElements());
-            
-            return PageResponse.from(photoResponsePage);
+            Store store = storeRepository.findById(request.getStoreId())
+                    .orElseThrow(() -> new PhotoException(ErrorMessage.STORE_NOT_FOUND));
+            // ToDo: Add FoodItem logic if foodItemId is not null
+
+            Photo photo = Photo.builder()
+                    .s3Key(request.getS3Key())
+                    .fileName(request.getFileName())
+                    .store(store)
+                    .fileSize(request.getFileSize())
+                    .imageWidth(request.getImageWidth())
+                    .imageHeight(request.getImageHeight())
+                    .isActive(true)
+                    .isFeatured(false)
+                    .build();
+
+            Photo savedPhoto = photoRepository.save(photo);
+
+            return PhotoResponse.from(savedPhoto, cloudfrontDomain);
         } catch (Exception e) {
-            log.error("getPhotos 실패 - foodId: {}, error: {}", foodId, e.getMessage(), e);
+            log.error("[PhotoService] Failed to register photo for user: {}. s3Key: {}. Error: {}", username, request.getS3Key(), e.getMessage());
+            throw new PhotoException(ErrorMessage.PHOTO_REGISTRATION_FAILED);
+        }
+    }
+
+    public PageResponse<PhotoResponse> getPhotosByStore(final Long storeId, final Pageable pageable) {
+        log.info("[PhotoService] getPhotosByStore for storeId: {}", storeId);
+        try {
+            Page<Photo> photoPage = photoRepository.findByStoreId(storeId, pageable);
+            return PageResponse.from(photoPage.map(photo -> PhotoResponse.from(photo, cloudfrontDomain)));
+        } catch (Exception e) {
+            log.error("[PhotoService] Failed to get photos for storeId: {}. Error: {}", storeId, e.getMessage());
+            throw new PhotoException(ErrorMessage.PHOTO_NOT_FOUND);
+        }
+    }
+    
+    public PhotoResponse getPhoto(final Long photoId) {
+        log.info("[PhotoService] getPhoto for photoId: {}", photoId);
+        try {
+            Photo photo = findPhotoById(photoId);
+            return PhotoResponse.from(photo, cloudfrontDomain);
+        } catch (Exception e) {
+            log.error("[PhotoService] Failed to get photo for photoId: {}. Error: {}", photoId, e.getMessage());
             throw new PhotoException(ErrorMessage.PHOTO_NOT_FOUND);
         }
     }
 
-    /**
-     * 대표 사진 설정
-     */
     @Transactional
-    public PhotoResponse setFeaturedPhoto(Long foodId, Long photoId, Long userId) {
-        log.info("setFeaturedPhoto 시작 - foodId: {}, photoId: {}, userId: {}", 
-                foodId, photoId, userId);
-        
+    public void deletePhoto(final String username, final Long photoId) {
+        log.info("[PhotoService] deletePhoto for user: {}, photoId: {}", username, photoId);
         try {
-            // TODO: 권한 검증 로직 추가
             Photo photo = findPhotoById(photoId);
-            
-            // TODO: 대표 사진 지정 로직 구현
-            
-            log.info("setFeaturedPhoto 성공 - foodId: {}, photoId: {}", foodId, photoId);
-            
-            return PhotoResponse.from(photo);
-        } catch (Exception e) {
-            log.error("setFeaturedPhoto 실패 - foodId: {}, photoId: {}, error: {}", 
-                    foodId, photoId, e.getMessage(), e);
-            throw new PhotoException(ErrorMessage.PHOTO_FEATURE_UPDATE_FAILED);
-        }
-    }
+            // ToDo: 권한 검증 로직 (username이 이 사진을 삭제할 권한이 있는지)
 
-    /**
-     * 사진 삭제
-     */
-    @Transactional
-    public void deletePhoto(Long photoId, Long userId) {
-        log.info("deletePhoto 시작 - photoId: {}, userId: {}", photoId, userId);
-        
-        try {
-            Photo photo = findPhotoById(photoId);
-            
-            // TODO: 권한 검증 로직 추가
-            // TODO: 파일 시스템에서 실제 파일 삭제 로직 추가
-            
-            photoRepository.delete(photo);
-            
-            log.info("deletePhoto 성공 - photoId: {}", photoId);
+            deleteS3Object(photo.getS3Key());
+            photo.setIsActive(false);
+            log.info("[PhotoService] Successfully deleted photoId: {}", photoId);
         } catch (Exception e) {
-            log.error("deletePhoto 실패 - photoId: {}, error: {}", photoId, e.getMessage(), e);
+            log.error("[PhotoService] Failed to delete photo for user: {}, photoId: {}. Error: {}", username, photoId, e.getMessage());
             throw new PhotoException(ErrorMessage.PHOTO_DELETE_FAILED);
         }
     }
 
-    // === 내부 유틸리티 메서드들 ===
-
-    /**
-     * 사진 엔티티 생성
-     */
-    private Photo createPhotoEntity(MultipartFile file, Long foodId) {
-        return Photo.builder()
-                .fileName(file.getOriginalFilename())
-                .filePath("temp/path") // TODO: 실제 파일 경로 설정
-                .fileSize((int) file.getSize())
-                .build();
-    }
-
-    /**
-     * 사진 ID로 조회
-     */
-    private Photo findPhotoById(Long photoId) {
+    private Photo findPhotoById(final Long photoId) {
         return photoRepository.findById(photoId)
                 .orElseThrow(() -> new PhotoException(ErrorMessage.PHOTO_NOT_FOUND));
     }
-} 
+
+    private void deleteS3Object(final String s3Key) {
+        try {
+            DeleteObjectRequest deleteObjectRequest = DeleteObjectRequest.builder()
+                    .bucket(bucket)
+                    .key(s3Key)
+                    .build();
+            s3Client.deleteObject(deleteObjectRequest);
+            log.info("[PhotoService] Successfully deleted S3 object with key: {}", s3Key);
+        } catch (Exception e) {
+            // S3에서 객체 삭제 실패 시 로깅만 하고 에러를 던지지는 않음 (DB 트랜잭션은 롤백되지 않도록)
+            log.error("[PhotoService] Failed to delete S3 object with key: {}. Error: {}", s3Key, e.getMessage());
+        }
+    }
+
+    private URL createPresignedUrl(final String s3Key) {
+        PutObjectRequest objectRequest = PutObjectRequest.builder()
+                .bucket(bucket)
+                .key(s3Key)
+                .build();
+
+        PutObjectPresignRequest presignRequest = PutObjectPresignRequest.builder()
+                .signatureDuration(Duration.ofMinutes(10)) // The URL will be valid for 10 minutes
+                .putObjectRequest(objectRequest)
+                .build();
+
+        return s3Presigner.presignPutObject(presignRequest).url();
+    }
+
+    private String createS3Key(final String fileName) {
+        Objects.requireNonNull(fileName, "fileName must not be null");
+        int lastDotIndex = fileName.lastIndexOf('.');
+        if (lastDotIndex == -1) {
+            throw new PhotoException(ErrorMessage.PHOTO_INVALID_FORMAT);
+        }
+        final String fileExtension = fileName.substring(lastDotIndex);
+        return "foodPhoto/" + UUID.randomUUID() + fileExtension;
+    }
+}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -71,3 +71,14 @@ oauth2:
 
 fcm:
   service-account-key-path: ${FCM_SERVICE_ACCOUNT_KEY_PATH}
+
+
+cloud:
+  aws:
+    s3:
+      bucket: chalpu-s3
+    cloudfront:
+      domain: https://cdn.chalpu.com 
+    credentials:
+      access-key: ${S3_ACCESS_KEY}
+      secret-key: ${S3_SECRET_KEY} 


### PR DESCRIPTION
## 어떤 기능인가요?

- 관리자가 "가이드" XML 파일을 S3에 업로드하고 관리(조회, 삭제)할 수 있는 API를 추가했습니다.
- 사진(Photo) 업로드 API의 Swagger 문서에 클라이언트가 Presigned URL을 사용하는 상세한 절차를 추가하여 사용성을 개선했습니다.

## 작업 상세 내용

- [x] 가이드(Guide) API 신규 개발 (`/api/guides`)
  - [x] Presigned URL을 이용한 XML 파일 업로드 기능
  - [x] 가이드 목록 조회 및 상세 조회 기능 (페이지네이션 적용)
  - [x] 가이드 삭제 기능 (S3 파일 포함)
  - [x] 모든 API에 어드민(`ROLE_ADMIN`) 권한 설정
- [x] 사진(Photo) API Swagger 문서 보강
  - [x] Presigned URL 사용법에 대한 클라이언트 처리 순서 명시
- [x] 개발용 유틸리티 컨트롤러 추가
  - [x] 테스트용 토큰 발급 API 추가 (`/util/token`)
  - [x] `TestUtilController`가 Git에 추적되지 않도록 `.gitignore`에 추가



