### PR TITLE
refactor: Feature/#3 api enhancement and testing branch 

### DIFF
--- a/src/main/java/com/example/chalpu/common/exception/ErrorMessage.java
+++ b/src/main/java/com/example/chalpu/common/exception/ErrorMessage.java
@@ -55,6 +55,7 @@ public enum ErrorMessage {
     STORE_ACCESS_DENIED(FORBIDDEN, "매장 접근 권한이 없습니다."),
     STORE_CREATE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "매장 생성에 실패했습니다."),
     STORE_UPDATE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "매장 정보 수정에 실패했습니다."),
+    STORE_DELETE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "매장 삭제에 실패했습니다."),
     STORE_OWNER_REQUIRED(FORBIDDEN, "매장 소유자 권한이 필요합니다."),
     STORE_MEMBER_NOT_FOUND(NOT_FOUND, "매장 구성원을 찾을 수 없습니다."),
     STORE_MEMBER_ALREADY_EXISTS(BAD_REQUEST, "이미 매장 구성원으로 등록되어 있습니다."),
@@ -64,8 +65,12 @@ public enum ErrorMessage {
     MENU_ACCESS_DENIED(FORBIDDEN, "메뉴 접근 권한이 없습니다."),
     MENU_CREATE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "메뉴 생성에 실패했습니다."),
     MENU_UPDATE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "메뉴 수정에 실패했습니다."),
+    MENU_DELETE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "메뉴 삭제에 실패했습니다."),
     MENU_ITEM_NOT_FOUND(NOT_FOUND, "메뉴 항목을 찾을 수 없습니다."),
     MENU_ITEM_CREATE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "메뉴 항목 생성에 실패했습니다."),
+    MENU_ITEM_UPDATE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "메뉴 항목 수정에 실패했습니다."),
+    MENU_ITEM_DELETE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "메뉴 항목 삭제에 실패했습니다."),
+    MENU_ITEM_NOT_IN_MENU(BAD_REQUEST, "해당 메뉴에 속한 아이템이 아닙니다."),
     
     // 음식 관련 에러
     FOOD_NOT_FOUND(NOT_FOUND, "음식을 찾을 수 없습니다."),

--- a/src/main/java/com/example/chalpu/fooditem/controller/FoodItemController.java
+++ b/src/main/java/com/example/chalpu/fooditem/controller/FoodItemController.java
@@ -1,13 +1,20 @@
 package com.example.chalpu.fooditem.controller;
 
 import com.example.chalpu.common.response.ApiResponse;
+import com.example.chalpu.common.response.PageResponse;
+import com.example.chalpu.fooditem.dto.FoodItemRequest;
 import com.example.chalpu.fooditem.dto.FoodItemResponse;
 import com.example.chalpu.fooditem.service.FoodItemService;
+import com.example.chalpu.oauth.security.jwt.UserDetailsImpl;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -18,14 +25,81 @@ public class FoodItemController {
 
     private final FoodItemService foodItemService;
 
-    @GetMapping("/{foodId}")
+    @GetMapping("/store/{storeId}")
     @Operation(
-        summary = "음식 상세",
-        description = "특정 음식의 상세 정보를 조회합니다.",
+        summary = "매장별 음식 목록 조회",
+        description = "특정 매장의 음식 목록을 페이지네이션하여 조회합니다.",
         security = { @SecurityRequirement(name = "bearerAuth") }
     )
-    public ResponseEntity<ApiResponse<FoodItemResponse>> getFoodItem(@PathVariable Long foodId) {
+    public ApiResponse<PageResponse<FoodItemResponse>> getFoodItems(
+            @PathVariable @Parameter(description = "매장 ID") Long storeId,
+            @PageableDefault(size = 20) Pageable pageable) {
+        PageResponse<FoodItemResponse> foodItems = foodItemService.getFoodItems(storeId, pageable);
+        return ApiResponse.success(foodItems);
+    }
+
+    @GetMapping("/{foodId}")
+    @Operation(
+        summary = "음식 상세 조회",
+        description = "특정 음식의 상세 정보를 조회합니다."
+    )
+    public ApiResponse<FoodItemResponse> getFoodItem(
+            @PathVariable @Parameter(description = "음식 ID") Long foodId) {
         FoodItemResponse foodItem = foodItemService.getFoodItem(foodId);
-        return ResponseEntity.ok(ApiResponse.success("음식 정보 조회가 완료되었습니다.", foodItem));
+        return ApiResponse.success(foodItem);
+    }
+
+    @PostMapping("/store/{storeId}")
+    @Operation(
+        summary = "음식 생성",
+        description = "새로운 음식을 생성합니다.",
+        security = { @SecurityRequirement(name = "bearerAuth") }
+    )
+    public ApiResponse<FoodItemResponse> createFoodItem(
+            @PathVariable @Parameter(description = "매장 ID") Long storeId,
+            @RequestBody FoodItemRequest request,
+            @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        FoodItemResponse foodItem = foodItemService.createFoodItem(storeId, request, userDetails.getId());
+        return ApiResponse.success(foodItem);
+    }
+
+    @PutMapping("/{foodId}")
+    @Operation(
+        summary = "음식 수정",
+        description = "기존 음식 정보를 수정합니다.",
+        security = { @SecurityRequirement(name = "bearerAuth") }
+    )
+    public ApiResponse<FoodItemResponse> updateFoodItem(
+            @PathVariable @Parameter(description = "음식 ID") Long foodId,
+            @RequestBody FoodItemRequest request,
+            @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        FoodItemResponse foodItem = foodItemService.updateFoodItem(foodId, request, userDetails.getId());
+        return ApiResponse.success(foodItem);
+    }
+
+    @DeleteMapping("/{foodId}")
+    @Operation(
+        summary = "음식 삭제",
+        description = "음식을 삭제합니다 (소프트 딜리트).",
+        security = { @SecurityRequirement(name = "bearerAuth") }
+    )
+    public ApiResponse<Void> deleteFoodItem(
+            @PathVariable @Parameter(description = "음식 ID") Long foodId,
+            @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        foodItemService.deleteFoodItem(foodId, userDetails.getId());
+        return ApiResponse.success();
+    }
+
+    @GetMapping("/store/{storeId}/search")
+    @Operation(
+        summary = "음식 검색",
+        description = "매장 내에서 음식명으로 검색합니다."
+    )
+    public ApiResponse<PageResponse<FoodItemResponse>> searchFoodItems(
+            @PathVariable @Parameter(description = "매장 ID") Long storeId,
+            @RequestParam @Parameter(description = "검색 키워드") String keyword,
+            @PageableDefault(size = 20) Pageable pageable) {
+        PageResponse<FoodItemResponse> foodItems = foodItemService.searchFoodItems(storeId, keyword, pageable);
+        return ApiResponse.success(foodItems);
     }
 } 

--- a/src/main/java/com/example/chalpu/fooditem/domain/FoodItem.java
+++ b/src/main/java/com/example/chalpu/fooditem/domain/FoodItem.java
@@ -1,11 +1,11 @@
 package com.example.chalpu.fooditem.domain;
 
 import com.example.chalpu.common.entity.BaseTimeEntity;
+import com.example.chalpu.fooditem.dto.FoodItemRequest;
+import com.example.chalpu.store.domain.Store;
 import jakarta.persistence.*;
 import lombok.*;
 import java.math.BigDecimal;
-
-import com.example.chalpu.store.domain.Store;
 
 @Entity
 @Table(name = "food_items")
@@ -31,6 +31,37 @@ public class FoodItem extends BaseTimeEntity {
     private String ingredients;
     private String cookingMethod;
     private BigDecimal price;
+    
     @Builder.Default
     private Boolean isActive = true;
+
+    // 정적 팩토리 메서드
+    public static FoodItem createFoodItem(Store store, FoodItemRequest request) {
+        return FoodItem.builder()
+                .store(store)
+                .foodName(request.getFoodName())
+                .description(request.getDescription())
+                .ingredients(request.getIngredients())
+                .cookingMethod(request.getCookingMethod())
+                .price(request.getPrice())
+                .isActive(request.getIsActive() != null ? request.getIsActive() : true)
+                .build();
+    }
+
+    // 업데이트 메서드
+    public void updateFoodItem(FoodItemRequest request) {
+        this.foodName = request.getFoodName();
+        this.description = request.getDescription();
+        this.ingredients = request.getIngredients();
+        this.cookingMethod = request.getCookingMethod();
+        this.price = request.getPrice();
+        if (request.getIsActive() != null) {
+            this.isActive = request.getIsActive();
+        }
+    }
+
+    // 소프트 딜리트
+    public void softDelete() {
+        this.isActive = false;
+    }
 } 

--- a/src/main/java/com/example/chalpu/fooditem/repository/FoodItemRepository.java
+++ b/src/main/java/com/example/chalpu/fooditem/repository/FoodItemRepository.java
@@ -5,11 +5,22 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import org.springframework.data.domain.Pageable;
+
+import java.util.Optional;
  
 @Repository
 public interface FoodItemRepository extends JpaRepository<FoodItem, Long> {
     Page<FoodItem> findByStoreId(Long storeId, Pageable pageable);
     
+    // 활성 음식만 조회
+    Page<FoodItem> findByStoreIdAndIsActiveTrue(Long storeId, Pageable pageable);
+    
     // 매장별 음식명 검색
     Page<FoodItem> findByStoreIdAndFoodNameContaining(Long storeId, String foodName, Pageable pageable);
+    
+    // 활성 음식만 검색
+    Page<FoodItem> findByStoreIdAndIsActiveTrueAndFoodNameContaining(Long storeId, String foodName, Pageable pageable);
+    
+    // 활성 음식만 단건 조회
+    Optional<FoodItem> findByIdAndIsActiveTrue(Long id);
 } 

--- a/src/main/java/com/example/chalpu/fooditem/service/FoodItemService.java
+++ b/src/main/java/com/example/chalpu/fooditem/service/FoodItemService.java
@@ -9,6 +9,7 @@ import com.example.chalpu.fooditem.dto.FoodItemResponse;
 import com.example.chalpu.fooditem.repository.FoodItemRepository;
 import com.example.chalpu.store.domain.Store;
 import com.example.chalpu.store.repository.StoreRepository;
+import com.example.chalpu.store.service.UserStoreRoleService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -26,24 +27,18 @@ public class FoodItemService {
 
     private final FoodItemRepository foodItemRepository;
     private final StoreRepository storeRepository;
+    private final UserStoreRoleService userStoreRoleService;
 
     /**
-     * 매장별 음식 아이템 목록 조회
+     * 매장별 음식 아이템 목록 조회 (활성 음식만)
      */
     public PageResponse<FoodItemResponse> getFoodItems(Long storeId, Pageable pageable) {
-        log.info("getFoodItems 시작 - storeId: {}, page: {}, size: {}", 
-                storeId, pageable.getPageNumber(), pageable.getPageSize());
-        
         try {
-            Page<FoodItem> foodItemPage = foodItemRepository.findByStoreId(storeId, pageable);
+            Page<FoodItem> foodItemPage = foodItemRepository.findByStoreIdAndIsActiveTrue(storeId, pageable);
             Page<FoodItemResponse> foodResponsePage = foodItemPage.map(FoodItemResponse::from);
-            
-            log.info("getFoodItems 성공 - storeId: {}, totalElements: {}", 
-                    storeId, foodItemPage.getTotalElements());
-            
             return PageResponse.from(foodResponsePage);
         } catch (Exception e) {
-            log.error("getFoodItems 실패 - storeId: {}, error: {}", storeId, e.getMessage(), e);
+            log.error("Failed to retrieve food items: storeId={}", storeId, e);
             throw new FoodException(ErrorMessage.FOOD_NOT_FOUND);
         }
     }
@@ -52,17 +47,11 @@ public class FoodItemService {
      * 음식 아이템 단건 조회
      */
     public FoodItemResponse getFoodItem(Long foodId) {
-        log.info("getFoodItem 시작 - foodId: {}", foodId);
-        
         try {
             FoodItem foodItem = findFoodItemById(foodId);
-            
-            log.info("getFoodItem 성공 - foodId: {}, foodName: {}", 
-                    foodId, foodItem.getFoodName());
-            
             return FoodItemResponse.from(foodItem);
         } catch (Exception e) {
-            log.error("getFoodItem 실패 - foodId: {}, error: {}", foodId, e.getMessage(), e);
+            log.error("Food item not found: id={}", foodId, e);
             throw new FoodException(ErrorMessage.FOOD_NOT_FOUND);
         }
     }
@@ -72,23 +61,20 @@ public class FoodItemService {
      */
     @Transactional
     public FoodItemResponse createFoodItem(Long storeId, FoodItemRequest foodItemRequest, Long userId) {
-        log.info("createFoodItem 시작 - storeId: {}, foodName: {}, userId: {}", 
-                storeId, foodItemRequest.getFoodName(), userId);
-        
         try {
-            // TODO: 권한 검증 로직 추가
+            validateUserStoreAccess(userId, storeId);
             Store store = findStoreById(storeId);
             
-            FoodItem foodItem = createFoodItemEntity(store, foodItemRequest);
+            FoodItem foodItem = FoodItem.createFoodItem(store, foodItemRequest);
             FoodItem savedFoodItem = foodItemRepository.save(foodItem);
             
-            log.info("createFoodItem 성공 - foodId: {}, foodName: {}", 
-                    savedFoodItem.getId(), savedFoodItem.getFoodName());
+            log.info("event=food_item_created, food_item_id={}, store_id={}, user_id={}", 
+                    savedFoodItem.getId(), storeId, userId);
             
             return FoodItemResponse.from(savedFoodItem);
         } catch (Exception e) {
-            log.error("createFoodItem 실패 - storeId: {}, foodName: {}, error: {}", 
-                    storeId, foodItemRequest.getFoodName(), e.getMessage(), e);
+            log.error("event=food_item_creation_failed, store_id={}, user_id={}, error_message={}", 
+                    storeId, userId, e.getMessage(), e);
             throw new FoodException(ErrorMessage.FOOD_CREATE_FAILED);
         }
     }
@@ -98,78 +84,65 @@ public class FoodItemService {
      */
     @Transactional
     public FoodItemResponse updateFoodItem(Long foodId, FoodItemRequest foodItemRequest, Long userId) {
-        log.info("updateFoodItem 시작 - foodId: {}, foodName: {}, userId: {}", 
-                foodId, foodItemRequest.getFoodName(), userId);
-        
         try {
-            // TODO: 권한 검증 로직 추가
             FoodItem foodItem = findFoodItemById(foodId);
+            validateUserStoreAccess(userId, foodItem.getStore().getId());
             
-            // 음식 아이템 정보 업데이트
-            // TODO: FoodItem 엔티티에 updateFoodItem 메서드 추가 필요
+            foodItem.updateFoodItem(foodItemRequest);
             
-            log.info("updateFoodItem 성공 - foodId: {}, foodName: {}", 
-                    foodId, foodItem.getFoodName());
+            log.info("event=food_item_updated, food_item_id={}, user_id={}", 
+                    foodId, userId);
             
             return FoodItemResponse.from(foodItem);
         } catch (Exception e) {
-            log.error("updateFoodItem 실패 - foodId: {}, error: {}", foodId, e.getMessage(), e);
+            log.error("event=food_item_update_failed, food_item_id={}, user_id={}, error_message={}", 
+                    foodId, userId, e.getMessage(), e);
             throw new FoodException(ErrorMessage.FOOD_UPDATE_FAILED);
         }
     }
 
     /**
-     * 음식 아이템 삭제
+     * 음식 아이템 삭제 (소프트 딜리트)
      */
     @Transactional
     public void deleteFoodItem(Long foodId, Long userId) {
-        log.info("deleteFoodItem 시작 - foodId: {}, userId: {}", foodId, userId);
-        
         try {
-            // TODO: 권한 검증 로직 추가
             FoodItem foodItem = findFoodItemById(foodId);
+            validateUserStoreAccess(userId, foodItem.getStore().getId());
             
-            // TODO: 관련 데이터 정리 (메뉴 아이템, 사진 등)
+            // 소프트 딜리트 처리
+            foodItem.softDelete();
             
-            foodItemRepository.delete(foodItem);
-            
-            log.info("deleteFoodItem 성공 - foodId: {}", foodId);
+            log.info("event=food_item_deleted, food_item_id={}, user_id={}", 
+                    foodId, userId);
         } catch (Exception e) {
-            log.error("deleteFoodItem 실패 - foodId: {}, error: {}", foodId, e.getMessage(), e);
+            log.error("event=food_item_deletion_failed, food_item_id={}, user_id={}, error_message={}", 
+                    foodId, userId, e.getMessage(), e);
             throw new FoodException(ErrorMessage.FOOD_UPDATE_FAILED);
         }
     }
 
     /**
-     * 음식 아이템 검색
+     * 음식 아이템 검색 (활성 음식만)
      */
     public PageResponse<FoodItemResponse> searchFoodItems(Long storeId, String keyword, Pageable pageable) {
-        log.info("searchFoodItems 시작 - storeId: {}, keyword: {}, page: {}, size: {}", 
-                storeId, keyword, pageable.getPageNumber(), pageable.getPageSize());
-        
         try {
-            Page<FoodItem> foodItemPage = foodItemRepository.findByStoreIdAndFoodNameContaining(
+            Page<FoodItem> foodItemPage = foodItemRepository.findByStoreIdAndIsActiveTrueAndFoodNameContaining(
                     storeId, keyword, pageable);
             Page<FoodItemResponse> foodResponsePage = foodItemPage.map(FoodItemResponse::from);
-            
-            log.info("searchFoodItems 성공 - storeId: {}, keyword: {}, totalElements: {}", 
-                    storeId, keyword, foodItemPage.getTotalElements());
-            
             return PageResponse.from(foodResponsePage);
         } catch (Exception e) {
-            log.error("searchFoodItems 실패 - storeId: {}, keyword: {}, error: {}", 
-                    storeId, keyword, e.getMessage(), e);
+            log.error("Food search error: storeId={}, keyword={}", storeId, keyword, e);
             throw new FoodException(ErrorMessage.FOOD_NOT_FOUND);
         }
     }
 
-    // === 내부 유틸리티 메서드들 ===
 
     /**
-     * 음식 아이템 ID로 조회
+     * 음식 아이템 ID로 조회 (활성 음식만)
      */
     private FoodItem findFoodItemById(Long foodId) {
-        return foodItemRepository.findById(foodId)
+        return foodItemRepository.findByIdAndIsActiveTrue(foodId)
                 .orElseThrow(() -> new FoodException(ErrorMessage.FOOD_NOT_FOUND));
     }
 
@@ -182,17 +155,20 @@ public class FoodItemService {
     }
 
     /**
-     * 음식 아이템 엔티티 생성
+     * 사용자 매장 접근 권한 검증
      */
-    private FoodItem createFoodItemEntity(Store store, FoodItemRequest foodItemRequest) {
-        return FoodItem.builder()
-                .store(store)
-                .foodName(foodItemRequest.getFoodName())
-                .description(foodItemRequest.getDescription())
-                .ingredients(foodItemRequest.getIngredients())
-                .cookingMethod(foodItemRequest.getCookingMethod())
-                .price(foodItemRequest.getPrice())
-                .isActive(foodItemRequest.getIsActive())
-                .build();
+    private void validateUserStoreAccess(Long userId, Long storeId) {
+        if (!userStoreRoleService.canUserAccessStore(userId, storeId)) {
+            throw new FoodException(ErrorMessage.STORE_ACCESS_DENIED);
+        }
+    }
+
+    /**
+     * 사용자 매장 관리 권한 검증
+     */
+    private void validateUserStoreManagement(Long userId, Long storeId) {
+        if (!userStoreRoleService.canUserManageStore(userId, storeId)) {
+            throw new FoodException(ErrorMessage.STORE_ACCESS_DENIED);
+        }
     }
 } 

--- a/src/main/java/com/example/chalpu/menu/controller/MenuController.java
+++ b/src/main/java/com/example/chalpu/menu/controller/MenuController.java
@@ -67,4 +67,29 @@ public class MenuController {
         MenuResponse menu = menuService.createMenu(storeId, menuRequest, currentUser.getId());
         return ResponseEntity.ok(ApiResponse.success("메뉴판 생성이 완료되었습니다.", menu));
     }
+
+    @PutMapping("/{menuId}")
+    @Operation(
+        summary = "메뉴판 수정",
+        description = "기존 메뉴판의 정보를 수정합니다.",
+        security = { @SecurityRequirement(name = "bearerAuth") }
+    )
+    public ResponseEntity<ApiResponse<MenuResponse>> updateMenu(
+            @PathVariable Long storeId,
+            @PathVariable Long menuId,
+            @RequestBody MenuRequest menuRequest,
+            @AuthenticationPrincipal UserDetailsImpl currentUser) {
+        MenuResponse menu = menuService.updateMenu(menuId, menuRequest, currentUser.getId());
+        return ResponseEntity.ok(ApiResponse.success("메뉴판 수정이 완료되었습니다.", menu));
+    }
+
+    @DeleteMapping("/{menuId}")
+    @Operation(summary = "메뉴판 삭제", description = "특정 메뉴판을 삭제합니다.")
+    public ResponseEntity<ApiResponse<Void>> deleteMenu(
+            @PathVariable Long storeId,
+            @PathVariable Long menuId,
+            @AuthenticationPrincipal UserDetailsImpl currentUser) {
+        menuService.deleteMenu(menuId, currentUser.getId());
+        return ResponseEntity.ok(ApiResponse.success("메뉴판 삭제가 완료되었습니다.", null));
+    }
 } 

--- a/src/main/java/com/example/chalpu/menu/controller/MenuItemController.java
+++ b/src/main/java/com/example/chalpu/menu/controller/MenuItemController.java
@@ -1,37 +1,65 @@
 package com.example.chalpu.menu.controller;
 
 import com.example.chalpu.common.response.ApiResponse;
+import com.example.chalpu.common.response.PageResponse;
+import com.example.chalpu.menu.dto.MenuItemOrderUpdateRequest;
 import com.example.chalpu.menu.dto.MenuItemRequest;
 import com.example.chalpu.menu.dto.MenuItemResponse;
-import com.example.chalpu.menu.service.MenuService;
+import com.example.chalpu.menu.service.MenuItemService;
 import com.example.chalpu.oauth.security.jwt.UserDetailsImpl;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.security.SecurityRequirement;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import java.net.URI;
+
 @RestController
-@RequestMapping("/api/menus/{menuId}/items")
 @RequiredArgsConstructor
-@Tag(name = "MenuItem", description = "메뉴 아이템 관련 API")
+@RequestMapping("/menus/{menuId}/items")
 public class MenuItemController {
 
-    private final MenuService menuService;
+    private final MenuItemService menuItemService;
 
     @PostMapping
-    @Operation(
-        summary = "메뉴판에 음식 추가",
-        description = "메뉴판에 새로운 음식을 추가합니다.",
-        security = { @SecurityRequirement(name = "bearerAuth") }
-    )
+    @Operation(summary = "메뉴 아이템 추가", description = "특정 메뉴에 음식 아이템을 추가합니다.")
     public ResponseEntity<ApiResponse<MenuItemResponse>> addMenuItem(
             @PathVariable Long menuId,
             @RequestBody MenuItemRequest menuItemRequest,
-            @AuthenticationPrincipal UserDetailsImpl currentUser) {
-        MenuItemResponse menuItem = menuService.addMenuItem(menuId, menuItemRequest, currentUser.getId());
-        return ResponseEntity.ok(ApiResponse.success("메뉴 아이템 추가가 완료되었습니다.", menuItem));
+            @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        MenuItemResponse response = menuItemService.addMenuItem(menuId, menuItemRequest, userDetails.getId());
+        return ResponseEntity.ok(ApiResponse.success("메뉴 아이템 추가가 완료되었습니다.", response));
+    }
+
+    @PatchMapping("/{menuItemId}/order")
+    @Operation(summary = "메뉴 아이템 표시 순서 수정", description = "특정 메뉴 아이템의 표시 순서를 수정합니다.")
+    public ResponseEntity<ApiResponse<MenuItemResponse>> updateMenuItemOrder(
+            @PathVariable Long menuItemId,
+            @RequestBody MenuItemOrderUpdateRequest request,
+            @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        MenuItemResponse response = menuItemService.updateMenuItemOrder(menuItemId, request, userDetails.getId());
+        return ResponseEntity.ok(ApiResponse.success("메뉴 아이템 순서 수정이 완료되었습니다.", response));
+    }
+
+    @DeleteMapping("/{menuItemId}")
+    @Operation(summary = "메뉴 아이템 삭제", description = "특정 메뉴에서 음식 아이템을 제거합니다.")
+    public ResponseEntity<ApiResponse<Void>> removeMenuItem(
+            @PathVariable Long menuId,
+            @PathVariable Long menuItemId,
+            @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        menuItemService.removeMenuItem(menuId, menuItemId, userDetails.getId());
+        return ResponseEntity.ok(ApiResponse.success("메뉴 아이템 삭제가 완료되었습니다.", null));
+    }
+
+    @GetMapping
+    @Operation(summary = "메뉴 아이템 목록 조회", description = "특정 메뉴에 속한 음식 아이템 목록을 조회합니다.")
+    public ResponseEntity<ApiResponse<PageResponse<MenuItemResponse>>> getMenuItems(
+            @PathVariable Long menuId,
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            Pageable pageable) {
+        PageResponse<MenuItemResponse> response = menuItemService.getMenuItems(menuId, userDetails.getId(), pageable);
+        return ResponseEntity.ok(ApiResponse.success("메뉴 아이템 목록 조회가 완료되었습니다.", response));
     }
 } 

--- a/src/main/java/com/example/chalpu/menu/domain/Menu.java
+++ b/src/main/java/com/example/chalpu/menu/domain/Menu.java
@@ -4,11 +4,12 @@ import com.example.chalpu.common.entity.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.*;
 import com.example.chalpu.store.domain.Store;
+import com.example.chalpu.menu.dto.MenuRequest;
 
 @Entity
 @Table(name = "menus")
-@Data
-@NoArgsConstructor
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
 @EqualsAndHashCode(callSuper = false)
@@ -29,4 +30,31 @@ public class Menu extends BaseTimeEntity {
 
     @Builder.Default
     private Boolean isActive = true;
+
+    // == 생성 메서드 == //
+    public static Menu createMenu(Store store, MenuRequest menuRequest) {
+        return Menu.builder()
+                .store(store)
+                .menuName(menuRequest.getMenuName())
+                .description(menuRequest.getDescription())
+                .isActive(menuRequest.getIsActive())
+                .build();
+    }
+
+    // == 비즈니스 로직 == //
+    /**
+     * 메뉴 정보 수정
+     */
+    public void updateMenu(MenuRequest menuRequest) {
+        this.menuName = menuRequest.getMenuName();
+        this.description = menuRequest.getDescription();
+        this.isActive = menuRequest.getIsActive();
+    }
+
+    /**
+     * 메뉴 비활성화 (소프트 딜리트)
+     */
+    public void softDelete() {
+        this.isActive = false;
+    }
 } 

--- a/src/main/java/com/example/chalpu/menu/domain/MenuItem.java
+++ b/src/main/java/com/example/chalpu/menu/domain/MenuItem.java
@@ -3,11 +3,12 @@ package com.example.chalpu.menu.domain;
 import jakarta.persistence.*;
 import lombok.*;
 import com.example.chalpu.fooditem.domain.FoodItem;
+import com.example.chalpu.menu.dto.MenuItemRequest;
 
 @Entity
 @Table(name = "menu_items")
-@Data
-@NoArgsConstructor
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
 public class MenuItem {
@@ -26,4 +27,32 @@ public class MenuItem {
     @Column(name = "display_order", nullable = false)
     @Builder.Default
     private Integer displayOrder = 1;
+
+    @Builder.Default
+    private Boolean isActive = true;
+
+    // == 생성 메서드 == //
+    public static MenuItem createMenuItem(Menu menu, FoodItem foodItem, MenuItemRequest menuItemRequest) {
+        return MenuItem.builder()
+                .menu(menu)
+                .foodItem(foodItem)
+                .displayOrder(menuItemRequest.getDisplayOrder())
+                .isActive(true)
+                .build();
+    }
+    
+    // == 비즈니스 로직 == //
+    /**
+     * 메뉴 아이템 비활성화 (소프트 딜리트)
+     */
+    public void softDelete() {
+        this.isActive = false;
+    }
+
+    /**
+     * 메뉴 아이템 표시 순서 변경
+     */
+    public void updateDisplayOrder(Integer displayOrder) {
+        this.displayOrder = displayOrder;
+    }
 } 

--- a/src/main/java/com/example/chalpu/menu/dto/MenuItemOrderUpdateRequest.java
+++ b/src/main/java/com/example/chalpu/menu/dto/MenuItemOrderUpdateRequest.java
@@ -1,0 +1,17 @@
+package com.example.chalpu.menu.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "메뉴 아이템 표시 순서 수정 요청")
+public class MenuItemOrderUpdateRequest {
+    @Schema(description = "새로운 표시 순서", example = "1", required = true)
+    private Integer displayOrder;
+} 

--- a/src/main/java/com/example/chalpu/menu/repository/MenuItemRepository.java
+++ b/src/main/java/com/example/chalpu/menu/repository/MenuItemRepository.java
@@ -1,9 +1,18 @@
 package com.example.chalpu.menu.repository;
 
+import com.example.chalpu.menu.domain.Menu;
 import com.example.chalpu.menu.domain.MenuItem;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
- 
+
+import java.util.List;
+import java.util.Optional;
+
 @Repository
 public interface MenuItemRepository extends JpaRepository<MenuItem, Long> {
+    List<MenuItem> findByMenu(Menu menu);
+    Optional<MenuItem> findByIdAndIsActiveTrue(Long menuItemId);
+    Page<MenuItem> findByMenuIdAndIsActiveTrue(Long menuId, Pageable pageable);
 } 

--- a/src/main/java/com/example/chalpu/menu/repository/MenuRepository.java
+++ b/src/main/java/com/example/chalpu/menu/repository/MenuRepository.java
@@ -7,11 +7,12 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface MenuRepository extends JpaRepository<Menu, Long> {
     
-    List<Menu> findByStoreId(Long storeId);
-    
-    Page<Menu> findByStoreId(Long storeId, Pageable pageable);
+    Page<Menu> findByStoreIdAndIsActiveTrue(Long storeId, Pageable pageable);
+
+    Optional<Menu> findByIdAndIsActiveTrue(Long menuId);
 } 

--- a/src/main/java/com/example/chalpu/menu/service/MenuItemService.java
+++ b/src/main/java/com/example/chalpu/menu/service/MenuItemService.java
@@ -1,0 +1,163 @@
+package com.example.chalpu.menu.service;
+
+import com.example.chalpu.common.exception.ErrorMessage;
+import com.example.chalpu.common.exception.FoodException;
+import com.example.chalpu.common.exception.MenuException;
+import com.example.chalpu.common.response.PageResponse;
+import com.example.chalpu.fooditem.domain.FoodItem;
+import com.example.chalpu.fooditem.repository.FoodItemRepository;
+import com.example.chalpu.menu.domain.Menu;
+import com.example.chalpu.menu.domain.MenuItem;
+import com.example.chalpu.menu.dto.MenuItemOrderUpdateRequest;
+import com.example.chalpu.menu.dto.MenuItemRequest;
+import com.example.chalpu.menu.dto.MenuItemResponse;
+import com.example.chalpu.menu.repository.MenuItemRepository;
+import com.example.chalpu.menu.repository.MenuRepository;
+import com.example.chalpu.store.service.UserStoreRoleService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MenuItemService {
+
+    private final MenuItemRepository menuItemRepository;
+    private final MenuRepository menuRepository;
+    private final FoodItemRepository foodItemRepository;
+    private final UserStoreRoleService userStoreRoleService;
+
+    /**
+     * 메뉴 아이템 추가
+     */
+    @Transactional
+    public MenuItemResponse addMenuItem(Long menuId, MenuItemRequest menuItemRequest, Long userId) {
+        try {
+            Menu menu = findActiveMenuById(menuId);
+            validateUserStoreManagement(userId, menu.getStore().getId());
+
+            FoodItem foodItem = findActiveFoodItemById(menuItemRequest.getFoodId());
+
+            MenuItem menuItem = MenuItem.createMenuItem(menu, foodItem, menuItemRequest);
+            MenuItem savedMenuItem = menuItemRepository.save(menuItem);
+
+            log.info("event=menu_item_added, menu_item_id={}, menu_id={}, food_id={}, user_id={}",
+                    savedMenuItem.getId(), menuId, foodItem.getId(), userId);
+
+            return MenuItemResponse.from(savedMenuItem);
+        } catch (Exception e) {
+            log.error("event=menu_item_add_failed, menu_id={}, food_id={}, user_id={}, error_message={}",
+                    menuId, menuItemRequest.getFoodId(), userId, e.getMessage(), e);
+            throw new MenuException(ErrorMessage.MENU_ITEM_CREATE_FAILED);
+        }
+    }
+
+    /**
+     * 메뉴 아이템 표시 순서 수정
+     */
+    @Transactional
+    public MenuItemResponse updateMenuItemOrder(Long menuItemId, MenuItemOrderUpdateRequest request, Long userId) {
+        try {
+            MenuItem menuItem = findActiveMenuItemById(menuItemId);
+            validateUserStoreManagement(userId, menuItem.getMenu().getStore().getId());
+
+            menuItem.updateDisplayOrder(request.getDisplayOrder());
+
+            log.info("event=menu_item_order_updated, menu_item_id={}, new_order={}, user_id={}",
+                    menuItemId, request.getDisplayOrder(), userId);
+
+            return MenuItemResponse.from(menuItem);
+        } catch (Exception e) {
+            log.error("event=menu_item_order_update_failed, menu_item_id={}, user_id={}, error_message={}",
+                    menuItemId, userId, e.getMessage(), e);
+            throw new MenuException(ErrorMessage.MENU_ITEM_UPDATE_FAILED);
+        }
+    }
+
+    /**
+     * 메뉴 아이템 목록 조회
+     */
+    public PageResponse<MenuItemResponse> getMenuItems(Long menuId, Long userId, Pageable pageable) {
+        try {
+            Menu menu = findActiveMenuById(menuId);
+            validateUserStoreAccess(userId, menu.getStore().getId());
+
+            Page<MenuItem> menuItemPage = menuItemRepository.findByMenuIdAndIsActiveTrue(menuId, pageable);
+            Page<MenuItemResponse> menuItemResponsePage = menuItemPage.map(MenuItemResponse::from);
+            return PageResponse.from(menuItemResponsePage);
+        } catch (Exception e) {
+            log.error("event=menu_items_get_failed, menu_id={}, user_id={}, error_message={}",
+                    menuId, userId, e.getMessage(), e);
+            throw e;
+        }
+    }
+
+    /**
+     * 메뉴 아이템 삭제 (소프트 딜리트)
+     */
+    @Transactional
+    public void removeMenuItem(Long menuId, Long menuItemId, Long userId) {
+        try {
+            MenuItem menuItem = findActiveMenuItemById(menuItemId);
+            validateUserStoreManagement(userId, menuItem.getMenu().getStore().getId());
+
+            if (!menuItem.getMenu().getId().equals(menuId)) {
+                throw new MenuException(ErrorMessage.MENU_ITEM_NOT_IN_MENU);
+            }
+
+            menuItem.softDelete();
+
+            log.info("event=menu_item_removed, menu_item_id={}, menu_id={}, user_id={}", 
+                    menuItemId, menuId, userId);
+        } catch (Exception e) {
+            log.error("event=menu_item_remove_failed, menu_item_id={}, user_id={}, error_message={}",
+                    menuItemId, userId, e.getMessage(), e);
+            throw new MenuException(ErrorMessage.MENU_ITEM_DELETE_FAILED);
+        }
+    }
+
+    /**
+     * 메뉴에 속한 모든 메뉴 아이템 비활성화 (소프트 딜리트)
+     */
+    @Transactional
+    public void softDeleteMenuItemsByMenu(Menu menu) {
+        List<MenuItem> menuItems = menuItemRepository.findByMenu(menu);
+        menuItems.forEach(MenuItem::softDelete);
+        log.info("event=menu_items_deleted_by_menu, menu_id={}, count={}", 
+                menu.getId(), menuItems.size());
+    }
+
+    private Menu findActiveMenuById(Long menuId) {
+        return menuRepository.findByIdAndIsActiveTrue(menuId)
+                .orElseThrow(() -> new MenuException(ErrorMessage.MENU_NOT_FOUND));
+    }
+
+    private FoodItem findActiveFoodItemById(Long foodId) {
+        return foodItemRepository.findByIdAndIsActiveTrue(foodId)
+                .orElseThrow(() -> new FoodException(ErrorMessage.FOOD_NOT_FOUND));
+    }
+
+    private MenuItem findActiveMenuItemById(Long menuItemId) {
+        return menuItemRepository.findByIdAndIsActiveTrue(menuItemId)
+                .orElseThrow(() -> new MenuException(ErrorMessage.MENU_ITEM_NOT_FOUND));
+    }
+
+    private void validateUserStoreAccess(Long userId, Long storeId) {
+        if (!userStoreRoleService.canUserAccessStore(userId, storeId)) {
+            throw new MenuException(ErrorMessage.STORE_ACCESS_DENIED);
+        }
+    }
+
+    private void validateUserStoreManagement(Long userId, Long storeId) {
+        if (!userStoreRoleService.canUserManageStore(userId, storeId)) {
+            throw new MenuException(ErrorMessage.STORE_ACCESS_DENIED);
+        }
+    }
+}

--- a/src/main/java/com/example/chalpu/menu/service/MenuService.java
+++ b/src/main/java/com/example/chalpu/menu/service/MenuService.java
@@ -2,20 +2,14 @@ package com.example.chalpu.menu.service;
 
 import com.example.chalpu.common.exception.ErrorMessage;
 import com.example.chalpu.common.exception.MenuException;
-import com.example.chalpu.common.exception.FoodException;
 import com.example.chalpu.common.response.PageResponse;
 import com.example.chalpu.menu.domain.Menu;
-import com.example.chalpu.menu.domain.MenuItem;
 import com.example.chalpu.menu.dto.MenuRequest;
 import com.example.chalpu.menu.dto.MenuResponse;
-import com.example.chalpu.menu.dto.MenuItemRequest;
-import com.example.chalpu.menu.dto.MenuItemResponse;
 import com.example.chalpu.menu.repository.MenuRepository;
-import com.example.chalpu.menu.repository.MenuItemRepository;
 import com.example.chalpu.store.domain.Store;
 import com.example.chalpu.store.repository.StoreRepository;
-import com.example.chalpu.fooditem.domain.FoodItem;
-import com.example.chalpu.fooditem.repository.FoodItemRepository;
+import com.example.chalpu.store.service.UserStoreRoleService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -30,24 +24,17 @@ import org.springframework.transaction.annotation.Transactional;
 public class MenuService {
 
     private final MenuRepository menuRepository;
-    private final MenuItemRepository menuItemRepository;
     private final StoreRepository storeRepository;
-    private final FoodItemRepository foodItemRepository;
+    private final UserStoreRoleService userStoreRoleService;
+    private final MenuItemService menuItemService;
 
     /**
-     * 매장별 메뉴 목록 조회
+     * 매장별 메뉴 목록 조회 (활성 메뉴만)
      */
     public PageResponse<MenuResponse> getMenus(Long storeId, Pageable pageable) {
-        log.info("getMenus 시작 - storeId: {}, page: {}, size: {}", 
-                storeId, pageable.getPageNumber(), pageable.getPageSize());
-        
         try {
-            Page<Menu> menuPage = menuRepository.findByStoreId(storeId, pageable);
+            Page<Menu> menuPage = menuRepository.findByStoreIdAndIsActiveTrue(storeId, pageable);
             Page<MenuResponse> menuResponsePage = menuPage.map(MenuResponse::from);
-            
-            log.info("getMenus 성공 - storeId: {}, totalElements: {}", 
-                    storeId, menuPage.getTotalElements());
-            
             return PageResponse.from(menuResponsePage);
         } catch (Exception e) {
             log.error("getMenus 실패 - storeId: {}, error: {}", storeId, e.getMessage(), e);
@@ -60,23 +47,20 @@ public class MenuService {
      */
     @Transactional
     public MenuResponse createMenu(Long storeId, MenuRequest menuRequest, Long userId) {
-        log.info("createMenu 시작 - storeId: {}, menuName: {}, userId: {}", 
-                storeId, menuRequest.getMenuName(), userId);
-        
         try {
-            // TODO: 권한 검증 로직 추가
+            validateUserStoreManagement(userId, storeId);
             Store store = findStoreById(storeId);
             
-            Menu menu = createMenuEntity(store, menuRequest);
+            Menu menu = Menu.createMenu(store, menuRequest);
             Menu savedMenu = menuRepository.save(menu);
             
-            log.info("createMenu 성공 - menuId: {}, menuName: {}", 
-                    savedMenu.getId(), savedMenu.getMenuName());
+            log.info("event=menu_created, menu_id={}, store_id={}, user_id={}",
+                    savedMenu.getId(), storeId, userId);
             
             return MenuResponse.from(savedMenu);
         } catch (Exception e) {
-            log.error("createMenu 실패 - storeId: {}, menuName: {}, error: {}", 
-                    storeId, menuRequest.getMenuName(), e.getMessage(), e);
+            log.error("event=menu_creation_failed, store_id={}, user_id={}, error_message={}", 
+                    storeId, userId, e.getMessage(), e);
             throw new MenuException(ErrorMessage.MENU_CREATE_FAILED);
         }
     }
@@ -86,155 +70,59 @@ public class MenuService {
      */
     @Transactional
     public MenuResponse updateMenu(Long menuId, MenuRequest menuRequest, Long userId) {
-        log.info("updateMenu 시작 - menuId: {}, menuName: {}, userId: {}", 
-                menuId, menuRequest.getMenuName(), userId);
-        
         try {
-            // TODO: 권한 검증 로직 추가
-            Menu menu = getMenu(menuId);
+            Menu menu = findMenuById(menuId);
+            validateUserStoreManagement(userId, menu.getStore().getId());
             
-            // 메뉴 정보 업데이트 (직접 필드 업데이트)
-            // TODO: Menu 엔티티에 updateMenu 메서드 추가 필요
+            menu.updateMenu(menuRequest);
             
-            log.info("updateMenu 성공 - menuId: {}, menuName: {}", 
-                    menu.getId(), menu.getMenuName());
+            log.info("event=menu_updated, menu_id={}, user_id={}", 
+                    menu.getId(), userId);
             
             return MenuResponse.from(menu);
         } catch (Exception e) {
-            log.error("updateMenu 실패 - menuId: {}, error: {}", menuId, e.getMessage(), e);
+            log.error("event=menu_update_failed, menu_id={}, user_id={}, error_message={}",
+                    menuId, userId, e.getMessage(), e);
             throw new MenuException(ErrorMessage.MENU_UPDATE_FAILED);
         }
     }
 
     /**
-     * 메뉴 삭제
+     * 메뉴 삭제 (소프트 딜리트)
      */
     @Transactional
     public void deleteMenu(Long menuId, Long userId) {
-        log.info("deleteMenu 시작 - menuId: {}, userId: {}", menuId, userId);
-        
         try {
-            // TODO: 권한 검증 로직 추가
-            Menu menu = getMenu(menuId);
+            Menu menu = findMenuById(menuId);
+            validateUserStoreManagement(userId, menu.getStore().getId());
             
-            // 메뉴 아이템들도 함께 삭제
-            // TODO: MenuItemRepository에 deleteByMenuId 메서드 추가 필요
-            menuRepository.delete(menu);
+            // 메뉴 비활성화
+            menu.softDelete();
             
-            log.info("deleteMenu 성공 - menuId: {}", menuId);
+            // 메뉴 아이템 비활성화 (위임)
+            menuItemService.softDeleteMenuItemsByMenu(menu);
+            
+            log.info("event=menu_deleted, menu_id={}, user_id={}", menuId, userId);
         } catch (Exception e) {
-            log.error("deleteMenu 실패 - menuId: {}, error: {}", menuId, e.getMessage(), e);
-            throw new MenuException(ErrorMessage.MENU_UPDATE_FAILED);
+            log.error("event=menu_deletion_failed, menu_id={}, user_id={}, error_message={}",
+                    menuId, userId, e.getMessage(), e);
+            throw new MenuException(ErrorMessage.MENU_DELETE_FAILED);
         }
     }
 
-    /**
-     * 메뉴 아이템 추가
-     */
-    @Transactional
-    public MenuItemResponse addMenuItem(Long menuId, MenuItemRequest menuItemRequest, Long userId) {
-        log.info("addMenuItem 시작 - menuId: {}, foodId: {}, userId: {}", 
-                menuId, menuItemRequest.getFoodId(), userId);
-        
-        try {
-            // TODO: 권한 검증 로직 추가
-            Menu menu = getMenu(menuId);
-            FoodItem foodItem = findFoodItemById(menuItemRequest.getFoodId());
-            
-            MenuItem menuItem = createMenuItemEntity(menu, foodItem, menuItemRequest);
-            MenuItem savedMenuItem = menuItemRepository.save(menuItem);
-            
-            log.info("addMenuItem 성공 - menuItemId: {}, menuId: {}, foodId: {}", 
-                    savedMenuItem.getId(), menuId, menuItemRequest.getFoodId());
-            
-            return MenuItemResponse.from(savedMenuItem);
-        } catch (Exception e) {
-            log.error("addMenuItem 실패 - menuId: {}, foodId: {}, error: {}", 
-                    menuId, menuItemRequest.getFoodId(), e.getMessage(), e);
-            throw new MenuException(ErrorMessage.MENU_ITEM_CREATE_FAILED);
-        }
-    }
-
-    /**
-     * 메뉴 아이템 삭제
-     */
-    @Transactional
-    public void removeMenuItem(Long menuId, Long menuItemId, Long userId) {
-        log.info("removeMenuItem 시작 - menuId: {}, menuItemId: {}, userId: {}", 
-                menuId, menuItemId, userId);
-        
-        try {
-            // TODO: 권한 검증 로직 추가
-            MenuItem menuItem = findMenuItemById(menuItemId);
-            
-            // 메뉴 ID 일치 확인
-            if (!menuItem.getMenu().getId().equals(menuId)) {
-                throw new MenuException(ErrorMessage.MENU_ITEM_NOT_FOUND);
-            }
-            
-            menuItemRepository.delete(menuItem);
-            
-            log.info("removeMenuItem 성공 - menuItemId: {}", menuItemId);
-        } catch (Exception e) {
-            log.error("removeMenuItem 실패 - menuItemId: {}, error: {}", menuItemId, e.getMessage(), e);
-            throw new MenuException(ErrorMessage.MENU_ITEM_CREATE_FAILED);
-        }
-    }
-
-    /**
-     * 메뉴 조회
-     */
-    public Menu getMenu(Long menuId) {
-        return menuRepository.findById(menuId)
+    private Menu findMenuById(Long menuId) {
+        return menuRepository.findByIdAndIsActiveTrue(menuId)
                 .orElseThrow(() -> new MenuException(ErrorMessage.MENU_NOT_FOUND));
     }
 
-    // === 내부 유틸리티 메서드들 ===
-
-    /**
-     * 매장 ID로 조회
-     */
     private Store findStoreById(Long storeId) {
         return storeRepository.findById(storeId)
                 .orElseThrow(() -> new MenuException(ErrorMessage.STORE_NOT_FOUND));
     }
 
-    /**
-     * 음식 아이템 ID로 조회
-     */
-    private FoodItem findFoodItemById(Long foodId) {
-        return foodItemRepository.findById(foodId)
-                .orElseThrow(() -> new FoodException(ErrorMessage.FOOD_NOT_FOUND));
-    }
-
-    /**
-     * 메뉴 아이템 ID로 조회
-     */
-    private MenuItem findMenuItemById(Long menuItemId) {
-        return menuItemRepository.findById(menuItemId)
-                .orElseThrow(() -> new MenuException(ErrorMessage.MENU_ITEM_NOT_FOUND));
-    }
-
-    /**
-     * 메뉴 엔티티 생성
-     */
-    private Menu createMenuEntity(Store store, MenuRequest menuRequest) {
-        return Menu.builder()
-                .store(store)
-                .menuName(menuRequest.getMenuName())
-                .description(menuRequest.getDescription())
-                .isActive(menuRequest.getIsActive())
-                .build();
-    }
-
-    /**
-     * 메뉴 아이템 엔티티 생성
-     */
-    private MenuItem createMenuItemEntity(Menu menu, FoodItem foodItem, MenuItemRequest menuItemRequest) {
-        return MenuItem.builder()
-                .menu(menu)
-                .foodItem(foodItem)
-                .displayOrder(menuItemRequest.getDisplayOrder())
-                .build();
+    private void validateUserStoreManagement(Long userId, Long storeId) {
+        if (!userStoreRoleService.canUserManageStore(userId, storeId)) {
+            throw new MenuException(ErrorMessage.STORE_ACCESS_DENIED);
+        }
     }
 } 

--- a/src/main/java/com/example/chalpu/store/service/StoreService.java
+++ b/src/main/java/com/example/chalpu/store/service/StoreService.java
@@ -9,7 +9,9 @@ import com.example.chalpu.store.repository.StoreRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -18,32 +20,57 @@ public class StoreService {
     private final StoreRepository storeRepository;
 
     public StoreResponse getStore(Long storeId) {
-        Store store = storeRepository.findById(storeId)
-                .orElseThrow(() -> new StoreException(ErrorMessage.STORE_NOT_FOUND));
-        return StoreResponse.from(store);
+        try {
+            Store store = storeRepository.findById(storeId)
+                    .orElseThrow(() -> new StoreException(ErrorMessage.STORE_NOT_FOUND));
+            return StoreResponse.from(store);
+        } catch (Exception e) {
+            log.error("event=store_get_failed, store_id={}, error_message={}", storeId, e.getMessage(), e);
+            throw e;
+        }
     }
 
     @Transactional
     public StoreResponse createStore(StoreRequest storeRequest) {
-        Store store = Store.createStore(storeRequest);
-        Store savedStore = storeRepository.save(store);
-        return StoreResponse.from(savedStore);
+        try {
+            Store store = Store.createStore(storeRequest);
+            Store savedStore = storeRepository.save(store);
+            log.info("event=store_created, store_id={}", savedStore.getId());
+            return StoreResponse.from(savedStore);
+        } catch (Exception e) {
+            log.error("event=store_creation_failed, store_name={}, error_message={}",
+                    storeRequest.getStoreName(), e.getMessage(), e);
+            throw new StoreException(ErrorMessage.STORE_CREATE_FAILED);
+        }
     }
 
     @Transactional
     public StoreResponse updateStore(Long storeId, StoreRequest storeRequest) {
-        Store store = storeRepository.findById(storeId)
-                .orElseThrow(() -> new StoreException(ErrorMessage.STORE_NOT_FOUND));
-        
-        store.updateStore(storeRequest);
-        Store updatedStore = storeRepository.save(store);
-        return StoreResponse.from(updatedStore);
+        try {
+            Store store = storeRepository.findById(storeId)
+                    .orElseThrow(() -> new StoreException(ErrorMessage.STORE_NOT_FOUND));
+            
+            store.updateStore(storeRequest);
+            log.info("event=store_updated, store_id={}", storeId);
+            return StoreResponse.from(store);
+        } catch (Exception e) {
+            log.error("event=store_update_failed, store_id={}, error_message={}",
+                    storeId, e.getMessage(), e);
+            throw new StoreException(ErrorMessage.STORE_UPDATE_FAILED);
+        }
     }
 
     @Transactional
     public void deleteStore(Long storeId) {
-        Store store = storeRepository.findById(storeId)
-                .orElseThrow(() -> new StoreException(ErrorMessage.STORE_NOT_FOUND));
-        storeRepository.delete(store);
+        try {
+            Store store = storeRepository.findById(storeId)
+                    .orElseThrow(() -> new StoreException(ErrorMessage.STORE_NOT_FOUND));
+            storeRepository.delete(store);
+            log.info("event=store_deleted, store_id={}", storeId);
+        } catch (Exception e) {
+            log.error("event=store_deletion_failed, store_id={}, error_message={}",
+                    storeId, e.getMessage(), e);
+            throw new StoreException(ErrorMessage.STORE_DELETE_FAILED);
+        }
     }
 } 

--- a/src/test/java/com/example/chalpu/menu/service/MenuItemServiceTest.java
+++ b/src/test/java/com/example/chalpu/menu/service/MenuItemServiceTest.java
@@ -1,0 +1,127 @@
+package com.example.chalpu.menu.service;
+
+import com.example.chalpu.common.exception.MenuException;
+import com.example.chalpu.fooditem.domain.FoodItem;
+import com.example.chalpu.fooditem.repository.FoodItemRepository;
+import com.example.chalpu.menu.domain.Menu;
+import com.example.chalpu.menu.domain.MenuItem;
+import com.example.chalpu.menu.dto.MenuItemRequest;
+import com.example.chalpu.menu.repository.MenuItemRepository;
+import com.example.chalpu.menu.repository.MenuRepository;
+import com.example.chalpu.store.domain.Store;
+import com.example.chalpu.store.service.UserStoreRoleService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class MenuItemServiceTest {
+
+    @InjectMocks
+    private MenuItemService menuItemService;
+
+    @Mock
+    private MenuItemRepository menuItemRepository;
+    @Mock
+    private MenuRepository menuRepository;
+    @Mock
+    private FoodItemRepository foodItemRepository;
+    @Mock
+    private UserStoreRoleService userStoreRoleService;
+
+    private Store store;
+    private Menu menu;
+    private FoodItem foodItem;
+    private MenuItem menuItem;
+    private Long userId = 1L;
+    private Long storeId = 1L;
+    private Long menuId = 1L;
+    private Long foodId = 1L;
+    private Long menuItemId = 1L;
+
+    @BeforeEach
+    void setUp() {
+        store = Store.builder().id(storeId).build();
+        menu = Menu.builder().id(menuId).store(store).menuName("기본 메뉴").isActive(true).build();
+        foodItem = FoodItem.builder().id(foodId).store(store).foodName("기본 음식").build();
+        menuItem = MenuItem.builder().id(menuItemId).menu(menu).foodItem(foodItem).isActive(true).build();
+    }
+
+    @Nested
+    @DisplayName("메뉴 아이템 추가 테스트")
+    class AddMenuItemTest {
+        @Test
+        @DisplayName("성공")
+        void addMenuItem_success() {
+            // given
+            MenuItemRequest request = new MenuItemRequest(foodId, 1);
+            given(menuRepository.findByIdAndIsActiveTrue(menuId)).willReturn(Optional.of(menu));
+            given(foodItemRepository.findByIdAndIsActiveTrue(foodId)).willReturn(Optional.of(foodItem));
+            given(userStoreRoleService.canUserManageStore(userId, storeId)).willReturn(true);
+            given(menuItemRepository.save(any(MenuItem.class))).willReturn(menuItem);
+
+            // when
+            menuItemService.addMenuItem(menuId, request, userId);
+
+            // then
+            verify(menuItemRepository).save(any(MenuItem.class));
+        }
+
+        @Test
+        @DisplayName("실패 - 메뉴 없음")
+        void addMenuItem_fail_menuNotFound() {
+            // given
+            MenuItemRequest request = new MenuItemRequest(foodId, 1);
+            given(menuRepository.findByIdAndIsActiveTrue(menuId)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> menuItemService.addMenuItem(menuId, request, userId))
+                    .isInstanceOf(MenuException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("메뉴 아이템 삭제 테스트")
+    class RemoveMenuItemTest {
+        @Test
+        @DisplayName("성공")
+        void removeMenuItem_success() {
+            // given
+            given(menuItemRepository.findByIdAndIsActiveTrue(menuItemId)).willReturn(Optional.of(menuItem));
+            given(userStoreRoleService.canUserManageStore(userId, storeId)).willReturn(true);
+
+            // when
+            menuItemService.removeMenuItem(menuId, menuItemId, userId);
+
+            // then
+            verify(menuItemRepository, never()).delete(any(MenuItem.class));
+        }
+
+        @Test
+        @DisplayName("실패 - 메뉴 아이템이 다른 메뉴에 속함")
+        void removeMenuItem_fail_itemNotInMenu() {
+            // given
+            Long anotherMenuId = 2L;
+            given(menuItemRepository.findByIdAndIsActiveTrue(menuItemId)).willReturn(Optional.of(menuItem));
+            given(userStoreRoleService.canUserManageStore(userId, storeId)).willReturn(true);
+
+            // when & then
+            assertThatThrownBy(() -> menuItemService.removeMenuItem(anotherMenuId, menuItemId, userId))
+                    .isInstanceOf(MenuException.class);
+            verify(menuItemRepository, never()).delete(any(MenuItem.class));
+        }
+    }
+} 

--- a/src/test/java/com/example/chalpu/menu/service/MenuServiceTest.java
+++ b/src/test/java/com/example/chalpu/menu/service/MenuServiceTest.java
@@ -1,0 +1,152 @@
+package com.example.chalpu.menu.service;
+
+import com.example.chalpu.common.exception.MenuException;
+import com.example.chalpu.common.response.PageResponse;
+import com.example.chalpu.menu.domain.Menu;
+import com.example.chalpu.menu.dto.MenuRequest;
+import com.example.chalpu.menu.dto.MenuResponse;
+import com.example.chalpu.menu.repository.MenuRepository;
+import com.example.chalpu.store.domain.Store;
+import com.example.chalpu.store.service.UserStoreRoleService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import java.util.Collections;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class MenuServiceTest {
+
+    @InjectMocks
+    private MenuService menuService;
+
+    @Mock
+    private MenuRepository menuRepository;
+    @Mock
+    private UserStoreRoleService userStoreRoleService;
+    @Mock
+    private MenuItemService menuItemService;
+
+    private Store store;
+    private Menu menu;
+    private Long userId = 1L;
+    private Long storeId = 1L;
+    private Long menuId = 1L;
+
+    @BeforeEach
+    void setUp() {
+        store = Store.builder().id(storeId).build();
+        menu = Menu.builder().id(menuId).store(store).menuName("기본 메뉴").isActive(true).build();
+    }
+
+    @Nested
+    @DisplayName("메뉴 생성 테스트")
+    class CreateMenuTest {
+        @Test
+        @DisplayName("성공")
+        void createMenu_success() {
+            // given
+            MenuRequest request = new MenuRequest("새 메뉴", "설명", true);
+            given(userStoreRoleService.canUserManageStore(userId, storeId)).willReturn(true);
+            given(menuRepository.save(any(Menu.class))).willReturn(menu);
+
+            // when
+            MenuResponse response = menuService.createMenu(storeId, request, userId);
+
+            // then
+            assertThat(response.getMenuName()).isEqualTo(menu.getMenuName());
+            verify(userStoreRoleService).canUserManageStore(userId, storeId);
+            verify(menuRepository).save(any(Menu.class));
+        }
+
+        @Test
+        @DisplayName("실패 - 권한 없음")
+        void createMenu_fail_unauthorized() {
+            // given
+            MenuRequest request = new MenuRequest("새 메뉴", "설명", true);
+            given(userStoreRoleService.canUserManageStore(userId, storeId)).willReturn(false);
+
+            // when & then
+            assertThatThrownBy(() -> menuService.createMenu(storeId, request, userId))
+                    .isInstanceOf(MenuException.class);
+            verify(menuRepository, never()).save(any(Menu.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("메뉴 수정 테스트")
+    class UpdateMenuTest {
+        @Test
+        @DisplayName("성공")
+        void updateMenu_success() {
+            // given
+            MenuRequest request = new MenuRequest("수정된 메뉴", "수정된 설명", false);
+            given(menuRepository.findByIdAndIsActiveTrue(menuId)).willReturn(Optional.of(menu));
+            given(userStoreRoleService.canUserManageStore(userId, storeId)).willReturn(true);
+
+            // when
+            MenuResponse response = menuService.updateMenu(menuId, request, userId);
+
+            // then
+            assertThat(response.getMenuName()).isEqualTo("수정된 메뉴");
+            assertThat(response.getIsActive()).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("메뉴 삭제 테스트 (소프트 딜리트)")
+    class DeleteMenuTest {
+        @Test
+        @DisplayName("성공")
+        void deleteMenu_success() {
+            // given
+            given(menuRepository.findByIdAndIsActiveTrue(menuId)).willReturn(Optional.of(menu));
+            given(userStoreRoleService.canUserManageStore(userId, storeId)).willReturn(true);
+
+            // when
+            menuService.deleteMenu(menuId, userId);
+
+            // then
+            assertThat(menu.getIsActive()).isFalse();
+            verify(userStoreRoleService).canUserManageStore(userId, storeId);
+            verify(menuItemService).softDeleteMenuItemsByMenu(menu);
+        }
+    }
+
+    @Nested
+    @DisplayName("메뉴 목록 조회 테스트")
+    class GetMenusTest {
+        @Test
+        @DisplayName("성공")
+        void getMenus_success() {
+            // given
+            Pageable pageable = PageRequest.of(0, 10);
+            Page<Menu> menuPage = new PageImpl<>(Collections.singletonList(menu), pageable, 1);
+            given(menuRepository.findByStoreIdAndIsActiveTrue(storeId, pageable)).willReturn(menuPage);
+
+            // when
+            PageResponse<MenuResponse> response = menuService.getMenus(storeId, pageable);
+
+            // then
+            assertThat(response.getContent()).hasSize(1);
+            assertThat(response.getContent().get(0).getMenuName()).isEqualTo(menu.getMenuName());
+        }
+    }
+} 

--- a/src/test/java/com/example/chalpu/photo/service/PhotoServiceTest.java
+++ b/src/test/java/com/example/chalpu/photo/service/PhotoServiceTest.java
@@ -1,0 +1,330 @@
+package com.example.chalpu.photo.service;
+
+import com.example.chalpu.common.exception.ErrorMessage;
+import com.example.chalpu.common.exception.PhotoException;
+import com.example.chalpu.common.response.PageResponse;
+import com.example.chalpu.photo.domain.Photo;
+import com.example.chalpu.photo.dto.PhotoRegisterRequest;
+import com.example.chalpu.photo.dto.PhotoResponse;
+import com.example.chalpu.photo.repository.PhotoRepository;
+import com.example.chalpu.store.domain.Store;
+import com.example.chalpu.store.repository.StoreRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.util.ReflectionTestUtils;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("PhotoService 테스트")
+class PhotoServiceTest {
+
+    @Mock
+    private PhotoRepository photoRepository;
+    
+    @Mock
+    private StoreRepository storeRepository;
+    
+    @Mock
+    private S3Client s3Client;
+    
+    @Mock
+    private S3Presigner s3Presigner;
+    
+    @InjectMocks
+    private PhotoService photoService;
+    
+    private Store testStore;
+    private Photo testPhoto;
+    private PhotoRegisterRequest testRegisterRequest;
+    
+    @BeforeEach
+    void setUp() {
+        // 설정값 주입
+        ReflectionTestUtils.setField(photoService, "bucket", "test-bucket");
+        ReflectionTestUtils.setField(photoService, "cloudfrontDomain", "https://cdn.chalpu.com");
+        
+        // 테스트 데이터 생성
+        testStore = Store.builder()
+                .id(1L)
+                .storeName("테스트 매장")
+                .businessType("한식")
+                .address("서울시 강남구")
+                .phone("02-1234-5678")
+                .businessRegistrationNumber("123-45-67890")
+                .build();
+        
+        testPhoto = Photo.builder()
+                .id(1L)
+                .store(testStore)
+                .s3Key("foodPhoto/test-image.jpg")
+                .fileName("test-image.jpg")
+                .fileSize(1024)
+                .imageWidth(1920)
+                .imageHeight(1080)
+                .isActive(true)
+                .isFeatured(false)
+                .build();
+        
+        testRegisterRequest = PhotoRegisterRequest.builder()
+                .s3Key("foodPhoto/test-image.jpg")
+                .fileName("test-image.jpg")
+                .storeId(1L)
+                .fileSize(1024)
+                .imageWidth(1920)
+                .imageHeight(1080)
+                .build();
+    }
+    
+    @Test
+    @DisplayName("사진 등록 성공")
+    void registerPhoto_Success() {
+        // given
+        String username = "testuser";
+        when(storeRepository.findById(anyLong())).thenReturn(Optional.of(testStore));
+        when(photoRepository.save(any(Photo.class))).thenReturn(testPhoto);
+        
+        // when
+        PhotoResponse result = photoService.registerPhoto(username, testRegisterRequest);
+        
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getId()).isEqualTo(1L);
+        assertThat(result.getStoreId()).isEqualTo(1L);
+        assertThat(result.getFileName()).isEqualTo("test-image.jpg");
+        assertThat(result.getFileSize()).isEqualTo(1024);
+        assertThat(result.getImageWidth()).isEqualTo(1920);
+        assertThat(result.getImageHeight()).isEqualTo(1080);
+        assertThat(result.getIsFeatured()).isFalse();
+        assertThat(result.getImageUrl()).isEqualTo("https://cdn.chalpu.com/foodPhoto/test-image.jpg");
+        
+        verify(storeRepository).findById(1L);
+        verify(photoRepository).save(any(Photo.class));
+    }
+    
+    @Test
+    @DisplayName("사진 등록 실패 - 매장 없음")
+    void registerPhoto_StoreNotFound_ThrowsException() {
+        // given
+        String username = "testuser";
+        when(storeRepository.findById(anyLong())).thenReturn(Optional.empty());
+        
+        // when & then
+        assertThatThrownBy(() -> photoService.registerPhoto(username, testRegisterRequest))
+                .isInstanceOf(PhotoException.class)
+                .hasMessageContaining(ErrorMessage.STORE_NOT_FOUND.getMessage());
+        
+        verify(storeRepository).findById(1L);
+        verify(photoRepository, never()).save(any(Photo.class));
+    }
+    
+    @Test
+    @DisplayName("매장별 사진 목록 조회 성공")
+    void getPhotosByStore_Success() {
+        // given
+        Long storeId = 1L;
+        Pageable pageable = PageRequest.of(0, 10);
+        List<Photo> photos = List.of(testPhoto);
+        Page<Photo> photoPage = new PageImpl<>(photos, pageable, 1);
+        
+        when(photoRepository.findByStoreId(storeId, pageable)).thenReturn(photoPage);
+        
+        // when
+        PageResponse<PhotoResponse> result = photoService.getPhotosByStore(storeId, pageable);
+        
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getContent()).hasSize(1);
+        assertThat(result.getPage()).isEqualTo(0);
+        assertThat(result.getSize()).isEqualTo(10);
+        assertThat(result.getTotalElements()).isEqualTo(1);
+        assertThat(result.getTotalPages()).isEqualTo(1);
+        assertThat(result.isHasNext()).isFalse();
+        assertThat(result.isHasPrevious()).isFalse();
+        
+        PhotoResponse photoResponse = result.getContent().get(0);
+        assertThat(photoResponse.getId()).isEqualTo(1L);
+        assertThat(photoResponse.getStoreId()).isEqualTo(1L);
+        assertThat(photoResponse.getFileName()).isEqualTo("test-image.jpg");
+        
+        verify(photoRepository).findByStoreId(storeId, pageable);
+    }
+    
+    @Test
+    @DisplayName("매장별 사진 목록 조회 - 빈 결과")
+    void getPhotosByStore_EmptyResult() {
+        // given
+        Long storeId = 1L;
+        Pageable pageable = PageRequest.of(0, 10);
+        Page<Photo> emptyPage = new PageImpl<>(List.of(), pageable, 0);
+        
+        when(photoRepository.findByStoreId(storeId, pageable)).thenReturn(emptyPage);
+        
+        // when
+        PageResponse<PhotoResponse> result = photoService.getPhotosByStore(storeId, pageable);
+        
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getContent()).isEmpty();
+        assertThat(result.getTotalElements()).isEqualTo(0);
+        assertThat(result.getTotalPages()).isEqualTo(0);
+        
+        verify(photoRepository).findByStoreId(storeId, pageable);
+    }
+    
+    @Test
+    @DisplayName("사진 상세 조회 성공")
+    void getPhoto_Success() {
+        // given
+        Long photoId = 1L;
+        when(photoRepository.findById(photoId)).thenReturn(Optional.of(testPhoto));
+        
+        // when
+        PhotoResponse result = photoService.getPhoto(photoId);
+        
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getId()).isEqualTo(1L);
+        assertThat(result.getStoreId()).isEqualTo(1L);
+        assertThat(result.getFileName()).isEqualTo("test-image.jpg");
+        assertThat(result.getFileSize()).isEqualTo(1024);
+        assertThat(result.getImageWidth()).isEqualTo(1920);
+        assertThat(result.getImageHeight()).isEqualTo(1080);
+        assertThat(result.getIsFeatured()).isFalse();
+        assertThat(result.getImageUrl()).isEqualTo("https://cdn.chalpu.com/foodPhoto/test-image.jpg");
+        
+        verify(photoRepository).findById(photoId);
+    }
+    
+    @Test
+    @DisplayName("사진 상세 조회 실패 - 사진 없음")
+    void getPhoto_PhotoNotFound_ThrowsException() {
+        // given
+        Long photoId = 1L;
+        when(photoRepository.findById(photoId)).thenReturn(Optional.empty());
+        
+        // when & then
+        assertThatThrownBy(() -> photoService.getPhoto(photoId))
+                .isInstanceOf(PhotoException.class)
+                .hasMessageContaining(ErrorMessage.PHOTO_NOT_FOUND.getMessage());
+        
+        verify(photoRepository).findById(photoId);
+    }
+    
+    @Test
+    @DisplayName("사진 삭제 성공")
+    void deletePhoto_Success() {
+        // given
+        String username = "testuser";
+        Long photoId = 1L;
+        when(photoRepository.findById(photoId)).thenReturn(Optional.of(testPhoto));
+        
+        // when
+        photoService.deletePhoto(username, photoId);
+        
+        // then
+        assertThat(testPhoto.getIsActive()).isFalse();
+        
+        verify(photoRepository).findById(photoId);
+        // S3 관련 부분은 패스 (S3Client 호출 검증 생략)
+    }
+    
+    @Test
+    @DisplayName("사진 삭제 실패 - 사진 없음")
+    void deletePhoto_PhotoNotFound_ThrowsException() {
+        // given
+        String username = "testuser";
+        Long photoId = 1L;
+        when(photoRepository.findById(photoId)).thenReturn(Optional.empty());
+        
+        // when & then
+        assertThatThrownBy(() -> photoService.deletePhoto(username, photoId))
+                .isInstanceOf(PhotoException.class)
+                .hasMessageContaining(ErrorMessage.PHOTO_NOT_FOUND.getMessage());
+        
+        verify(photoRepository).findById(photoId);
+        // S3 관련 부분은 패스 (S3Client 호출 검증 생략)
+    }
+    
+    @Test
+    @DisplayName("사진 등록 시 FoodItem이 있는 경우")
+    void registerPhoto_WithFoodItem_Success() {
+        // given
+        String username = "testuser";
+        PhotoRegisterRequest requestWithFoodItem = PhotoRegisterRequest.builder()
+                .s3Key("foodPhoto/test-image.jpg")
+                .fileName("test-image.jpg")
+                .storeId(1L)
+                .foodItemId(10L)
+                .fileSize(1024)
+                .imageWidth(1920)
+                .imageHeight(1080)
+                .build();
+        
+        when(storeRepository.findById(anyLong())).thenReturn(Optional.of(testStore));
+        when(photoRepository.save(any(Photo.class))).thenReturn(testPhoto);
+        
+        // when
+        PhotoResponse result = photoService.registerPhoto(username, requestWithFoodItem);
+        
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getId()).isEqualTo(1L);
+        assertThat(result.getStoreId()).isEqualTo(1L);
+        
+        verify(storeRepository).findById(1L);
+        verify(photoRepository).save(any(Photo.class));
+    }
+    
+    @Test
+    @DisplayName("CloudFront 도메인이 null인 경우 URL 생성")
+    void photoResponse_NullCloudfrontDomain_ReturnsNullUrl() {
+        // given
+        ReflectionTestUtils.setField(photoService, "cloudfrontDomain", null);
+        when(photoRepository.findById(anyLong())).thenReturn(Optional.of(testPhoto));
+        
+        // when
+        PhotoResponse result = photoService.getPhoto(1L);
+        
+        // then
+        assertThat(result.getImageUrl()).isNull();
+        
+        verify(photoRepository).findById(1L);
+    }
+    
+    @Test
+    @DisplayName("CloudFront 도메인이 슬래시로 끝나는 경우 URL 생성")
+    void photoResponse_CloudfrontDomainWithSlash_CreatesCorrectUrl() {
+        // given
+        ReflectionTestUtils.setField(photoService, "cloudfrontDomain", "https://cdn.chalpu.com/");
+        when(photoRepository.findById(anyLong())).thenReturn(Optional.of(testPhoto));
+        
+        // when
+        PhotoResponse result = photoService.getPhoto(1L);
+        
+        // then
+        assertThat(result.getImageUrl()).isEqualTo("https://cdn.chalpu.com/foodPhoto/test-image.jpg");
+        
+        verify(photoRepository).findById(1L);
+    }
+} 


### PR DESCRIPTION
## 어떤 기능인가요?
- 메뉴(`Menu`) 및 메뉴 아이템(`MenuItem`) 관련 API의 기능을 개선하고, 전반적인 코드 품질을 향상시키기 위한 리팩토링을 진행했습니다.
- `ApiResponse`를 사용하여 응답 형식을 일관성 있게 통일하고, 구조화된 로깅을 적용하여 유지보수성을 높였습니다.
- 단일 책임 원칙(SRP)에 따라 `MenuService`와 `MenuItemService`를 분리했습니다.

## 작업 상세 내용
- **기능 추가 및 개선**
    - [x] `MenuController`: 메뉴 정보 수정(`PUT`) API 추가
    - [x] `MenuItemController`: 메뉴 아이템 표시 순서 변경(`PATCH`) API 추가
    - [x] `FoodItem`: 이름으로 음식을 검색하는 기능 추가

- **리팩토링**
    - [x] `MenuItemController`, `FoodItemController`: `ResponseEntity`를 직접 반환하던 로직을 `ApiResponse`로 감싸도록 통일
    - [x] `Menu`, `FoodItem` 엔티티: `create`, `update`, `softDelete` 등 비즈니스 로직을 엔티티 내부로 이동
    - [x] `MenuService`와 `MenuItemService` 분리하여 단일 책임 원칙 준수
    - [x] 다수 서비스(`Auth`, `Store`, `Photo` 등)에 구조화된 로깅(Structured Logging) 컨벤션 적용

- **테스트**
    - [x] `MenuServiceTest`, `MenuItemServiceTest`: 서비스 분리에 따른 테스트 코드 추가 및 수정
    - [x] `PhotoServiceTest`: 테스트 코드 추가